### PR TITLE
added `std::size_t LGFXBase::vprintf(const char *format, va_list arg)`

### DIFF
--- a/src/lgfx/v1/LGFXBase.cpp
+++ b/src/lgfx/v1/LGFXBase.cpp
@@ -1947,34 +1947,38 @@ namespace lgfx
     return write(floatToStr(number, buf, len, digits));
   }
 
-#if !defined (ARDUINO)
-  std::size_t LGFXBase::printf(const char * format, ...)
+  std::size_t LGFXBase::vprintf(const char *format, va_list arg)
   {
     char loc_buf[64];
     char * temp = loc_buf;
-    va_list arg;
     va_list copy;
-    va_start(arg, format);
     va_copy(copy, arg);
     std::size_t len = vsnprintf(temp, sizeof(loc_buf), format, copy);
-    va_end(copy);
-
     if (len >= sizeof(loc_buf)){
       temp = (char*) malloc(len+1);
       if (temp == nullptr) {
-        va_end(arg);
         return 0;
       }
       len = vsnprintf(temp, len+1, format, arg);
     }
-    va_end(arg);
     len = write((std::uint8_t*)temp, len);
     if (temp != loc_buf){
       free(temp);
     }
     return len;
   }
-#endif
+
+  #if !defined (ARDUINO)
+  std::size_t LGFXBase::printf(const char * format, ...) 
+  {
+    va_list arg_ptr;
+    va_start(arg_ptr, format);
+    std::size_t len = vprintf(format, arg_ptr);
+    va_end(arg_ptr);
+
+    return len;
+  }
+  #endif
 
   void LGFXBase::setFont(const IFont* font)
   {

--- a/src/lgfx/v1/LGFXBase.hpp
+++ b/src/lgfx/v1/LGFXBase.hpp
@@ -22,6 +22,7 @@ Contributors:
 #endif
 
 #include <cstdint>
+#include <stdarg.h>
 
 #include "platforms/common.hpp"
 #include "misc/enum.hpp"
@@ -652,6 +653,7 @@ namespace lgfx
   #endif
     std::size_t write(const std::uint8_t *buf, std::size_t size) { std::size_t n = 0; this->startWrite(); while (size--) { n += write(*buf++); } this->endWrite(); return n; }
     std::size_t write(std::uint8_t utf8);
+    size_t vprintf(const char *format, va_list arg);
 
 
 


### PR DESCRIPTION
　外部で printf みたいな引数未定な関数を作って呼び出したいとき、呼び出される側が vprintf を実装してくれていたほうが都合がよいものの、Arduino の Stream にはvprintf が実装されていません。
　そもそも Arduino 以外の場合に向けて printf を実装してくれているので、その骨子を生かしつつ vprintf を用意し、Arduino 以外向け printf を vprintf を使うように改変してみましたが、いかがでしょうか。

　提案の段階なので Draft PR にしておきました。