### PR TITLE
Update library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/m5stack/M5GFX.git"
   },
   "version": "0.0.20",
-  "frameworks": "arduino",
+  "frameworks": ["arduino", "espidf"],
   "platforms": "espressif32",
   "headers": "M5GFX.h"
 }


### PR DESCRIPTION
Add `"espidf"` to frameworks line so platformio will allow its use with the esp-idf framework