### PR TITLE
Bus_SPI-cpp: make it compile for ESP-IDF projects with an Arduino com…

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
@@ -46,27 +46,27 @@ Contributors:
 #if defined (ARDUINO) // Arduino ESP32
  #include <soc/periph_defs.h>
  #include <esp32-hal-cpu.h>
-#else
- #include <driver/spi_master.h>
+#endif
+#include <driver/spi_master.h>
 
- #if defined ( CONFIG_IDF_TARGET_ESP32S3 )
-  #if __has_include (<esp32s3/rom/gpio.h>)
-    #include <esp32s3/rom/gpio.h>
-  #else
-    #include <rom/gpio.h>
-  #endif
- #elif defined ( CONFIG_IDF_TARGET_ESP32S2 )
-  #if __has_include (<esp32s2/rom/gpio.h>)
-    #include <esp32s2/rom/gpio.h>
-  #else
-    #include <rom/gpio.h>
-  #endif
+#if defined ( CONFIG_IDF_TARGET_ESP32S3 )
+ #if __has_include (<esp32s3/rom/gpio.h>)
+ 
+   #include <esp32s3/rom/gpio.h>
  #else
-  #if __has_include (<esp32/rom/gpio.h>)
-    #include <esp32/rom/gpio.h>
-  #else
-    #include <rom/gpio.h>
-  #endif
+   #include <rom/gpio.h>
+ #endif
+#elif defined ( CONFIG_IDF_TARGET_ESP32S2 )
+ #if __has_include (<esp32s2/rom/gpio.h>)
+   #include <esp32s2/rom/gpio.h>
+ #else
+   #include <rom/gpio.h>
+ #endif
+#else
+ #if __has_include (<esp32/rom/gpio.h>)
+   #include <esp32/rom/gpio.h>
+ #else
+   #include <rom/gpio.h>
  #endif
 #endif
 

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
@@ -49,26 +49,15 @@ Contributors:
 #endif
 #include <driver/spi_master.h>
 
-#if defined ( CONFIG_IDF_TARGET_ESP32S3 )
- #if __has_include (<esp32s3/rom/gpio.h>)
- 
-   #include <esp32s3/rom/gpio.h>
- #else
-   #include <rom/gpio.h>
- #endif
-#elif defined ( CONFIG_IDF_TARGET_ESP32S2 )
- #if __has_include (<esp32s2/rom/gpio.h>)
-   #include <esp32s2/rom/gpio.h>
- #else
-   #include <rom/gpio.h>
- #endif
+#if defined ESP_IDF_VERSION_MAJOR && ESP_IDF_VERSION_MAJOR >= 5
+    #include <rom/gpio.h> // dispatched by core
+#elif defined ( CONFIG_IDF_TARGET_ESP32S3 ) && __has_include (<esp32s3/rom/gpio.h>)
+   #include <esp32s3/rom/gpio.h>  // dispatched by config
+#elif defined ( CONFIG_IDF_TARGET_ESP32S2 ) && __has_include (<esp32s2/rom/gpio.h>)
+   #include <esp32s2/rom/gpio.h>  // dispatched by config
 #else
- #if __has_include (<esp32/rom/gpio.h>)
-   #include <esp32/rom/gpio.h>
- #else
-   #include <rom/gpio.h>
- #endif
-#endif
+   #include <rom/gpio.h> // dispatched by core
+#endif   
 
 #ifndef SPI_PIN_REG
  #define SPI_PIN_REG SPI_MISC_REG


### PR DESCRIPTION
…ponent

in this case, both ARDUINO and CONFIG_IDF_TARGET_ESP32XX can be set

rearrange include logic to cater for this case