### PR TITLE
Light_PWM.cpp: adapt for LEDC API changes in Arduino 3.0

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -41,7 +41,13 @@ namespace lgfx
 
 #if defined ( ARDUINO )
 
-#if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+#if defined ESP_ARDUINO_VERSION
+  #if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+    #define LEDC_USE_IDF_V5 // esp32-arduino core 3.x.x uses the new ledC syntax
+  #endif   
+#endif
+
+#if defined LEDC_USE_IDF_V5
     ledcSetup(_cfg.pwm_channel, _cfg.freq, PWM_BITS);
     ledcAttachPin(_cfg.pin_bl, _cfg.pwm_channel);
     setBrightness(brightness);

--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -22,6 +22,7 @@ Contributors:
 
 #if defined ( ARDUINO )
  #include <esp32-hal-ledc.h>
+ #include <esp_arduino_version.h>
 #else
  #include <driver/ledc.h>
 #endif
@@ -40,10 +41,14 @@ namespace lgfx
 
 #if defined ( ARDUINO )
 
+#if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3, 0, 0)
     ledcSetup(_cfg.pwm_channel, _cfg.freq, PWM_BITS);
     ledcAttachPin(_cfg.pin_bl, _cfg.pwm_channel);
     setBrightness(brightness);
-
+#else
+    ledcAttach(_cfg.pin_bl, _cfg.freq, PWM_BITS); 
+    setBrightness(brightness);
+#endif
 #else
 
     static ledc_channel_config_t ledc_channel;


### PR DESCRIPTION
see https://github.com/espressif/arduino-esp32/blob/601efed98fb224a52ca8f2c9210eb035ea46702f/docs/source/migration_guides/2.x_to_3.0.rst#ledc

it seems the pwm channels are now internally managed in ledcAttach() so _cfg.pwm_channel will be unused

an example pio project for a Core2 and CoreS3 is here: https://github.com/mhaberler/M5GFX-arduino3/blob/main/platformio.ini

