### PR TITLE
DataWrapper.hpp: fix template arguments

### DIFF
--- a/src/lgfx/v1/misc/DataWrapper.hpp
+++ b/src/lgfx/v1/misc/DataWrapper.hpp
@@ -104,7 +104,7 @@ namespace lgfx
   template <>
   struct DataWrapperT<FILE> : public DataWrapper
   {
-    DataWrapperT<FILE>(FILE* fp = nullptr) : DataWrapper() , _fp { fp }
+    DataWrapperT(FILE* fp = nullptr) : DataWrapper() , _fp { fp }
     {
       need_transaction = true;
     }
@@ -134,7 +134,7 @@ namespace lgfx
   template <>
   struct DataWrapperT<void> : public DataWrapperT<FILE>
   {
-    DataWrapperT<void>(void) : DataWrapperT<FILE>() {}
+    DataWrapperT(void) : DataWrapperT<FILE>() {}
   };
 #else
   template <>

--- a/src/lgfx/v1/misc/DataWrapper.hpp
+++ b/src/lgfx/v1/misc/DataWrapper.hpp
@@ -140,7 +140,7 @@ namespace lgfx
   template <>
   struct DataWrapperT<void> : public DataWrapper
   {
-    DataWrapperT<void>(void) : DataWrapper() { }
+    DataWrapperT(void) : DataWrapper() { }
     int read(uint8_t *buf, uint32_t len) override { return false; }
     void skip(int32_t offset) override { }
     bool seek(uint32_t offset) override { return false; }


### PR DESCRIPTION
to keep M5GFX/develop (and I guess 0.1.11) building with Arduino-3.0 this patch is needed

gcc12.2 is used in Arduino-3.0 and it is pickier than gcc8

maybe want to make that conditional on the GCC version? 
