### PR TITLE
LGFX_Button に関数を追加

### DIFF
--- a/src/lgfx/v1/LGFX_Button.cpp
+++ b/src/lgfx/v1/LGFX_Button.cpp
@@ -38,9 +38,14 @@ namespace lgfx
     _h   = h;
     _textsize_x = textsize_x;
     _textsize_y = textsize_y <= std::numeric_limits<float>::epsilon() ? textsize_x : textsize_y;
-    strncpy(_label, label, 11);
+    setLabelText(label);
   }
 
+ void LGFX_Button::setLabelText(const char* label)
+ {
+   strncpy(_label, label, label_length);
+ }
+ 
   // Adjust text datum and x, y deltas
   void LGFX_Button::setLabelDatum(int16_t x_delta, int16_t y_delta, textdatum_t datum)
   {

--- a/src/lgfx/v1/LGFX_Button.hpp
+++ b/src/lgfx/v1/LGFX_Button.hpp
@@ -51,8 +51,12 @@ namespace lgfx
       _init_button(gfx, x, y, w, h, label, textsize_x, textsize_y);
     }
 
+    void setLabelText(const char* label);
     void setLabelDatum(int16_t x_delta, int16_t y_delta, textdatum_t datum = middle_center);
-
+    template<typename T> void setOutlineColor(const T& clr) { _outlinecolor = lgfx::convert_to_rgb888(clr); }
+    template<typename T> void setFillColor(const T& clr) { _fillcolor = lgfx::convert_to_rgb888(clr); }
+    template<typename T> void setTextColor(const T& clr) { _textcolor = lgfx::convert_to_rgb888(clr); }
+      
     void drawButton(bool inverted = false, const char* long_name = nullptr);
 
     bool contains(int16_t x, int16_t y) const
@@ -88,7 +92,8 @@ namespace lgfx
     uint32_t _fillcolor    = 0;
     uint32_t _textcolor    = 0xFFFFFF;
     textdatum_t _textdatum = middle_center; // Text size multiplier and text datum for button
-    char _label[12]; // Button text is 11 chars maximum unless long_name used
+    static constexpr size_t label_length = 11;
+    char _label[label_length + 1]; // Button text is 11 chars maximum unless long_name used
     float _textsize_x, _textsize_y;
     bool _pressed, _last_press; // Button states
   };


### PR DESCRIPTION
ボタンを作成後、ラベルと色の変更を手軽にできるように関数を追加してみました。  
(現状では initButton でなんとかしなくはならないので)

よろしくご検討ください。

- setLabelText  
ラベル文字列の変更
- setOutlineColor
- setFillColor
- setTextColor  
各色の変更

---
Add some methods to LGFX_Button.
- setLabelText  
Change the label string.
- setOutlineColor
- setFillColor
- setTextColor  
Change the each color.
