### PR TITLE
Support custom screen resolution via define settings when using SDL

### DIFF
--- a/examples/PlatformIO_SDL/platformio.ini
+++ b/examples/PlatformIO_SDL/platformio.ini
@@ -29,6 +29,14 @@ build_flags = -O0 -xc++ -std=c++14 -lSDL2
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2" ; for arm mac homebrew SDL2
   -L"${sysenv.HOMEBREW_PREFIX}/lib"          ; for arm mac homebrew SDL2
 
+[env:native_arm_customize]
+extends = native
+platform = native
+build_flags = ${env:native_arm.build_flags}
+  -DM5GFX_ROTATION=0
+  -DM5GFX_WINDOW_WIDTH=100
+  -DM5GFX_WINDOW_HEIGHT=100
+
 [env:native_StickCPlus]
 extends = native
 platform = native

--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -1569,6 +1569,11 @@ init_clear:
     }
 #endif
 
+#if defined (M5GFX_WINDOW_WIDTH) && defined (M5GFX_WINDOW_HEIGHT)
+    w = M5GFX_WINDOW_WIDTH;
+    h = M5GFX_WINDOW_HEIGHT;
+#endif
+
     pnl_cfg.memory_width = w;
     pnl_cfg.panel_width = w;
     pnl_cfg.memory_height = h;


### PR DESCRIPTION
1. define M5GFX_WINDOW_WIDTH and M5GFX_WINDOW_HEIGHT to set screen resolution.
2. M5GFX_WINDOW_WIDTH and M5GFX_WINDOW_HEIGHT need to be declared at the same time.

