### PR TITLE
Fixes for ESP-IDF 5.2

### DIFF
--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -5,6 +5,7 @@
 
 #if defined ( ESP_PLATFORM )
 
+#include <cstdint>
 #include <sdkconfig.h>
 #include <nvs.h>
 #include <esp_log.h>

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -486,12 +486,10 @@ namespace lgfx
         buscfg.flags = SPICOMMON_BUSFLAG_MASTER;
         buscfg.intr_flags = 0;
 #if defined (ESP_IDF_VERSION_VAL)
- #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
+ #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
         buscfg.isr_cpu_id = ESP_INTR_CPU_AFFINITY_AUTO;
- #else
-  #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0))
+ #elif (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0))
         buscfg.isr_cpu_id = INTR_CPU_ID_AUTO;
-  #endif
  #endif
 #endif
         if (ESP_OK != spi_bus_initialize(static_cast<spi_host_device_t>(spi_host), &buscfg, dma_channel))


### PR DESCRIPTION
M5GFX did not compile for ESP-IDF v5.2
I've made the fixes and tested them on v5.2 and v5.1.2
I also took the liberty to simplify the nested if statements.

- `<stdint>` include was required for `std::` prefix to work with int types
- `ESP_INTR_CPU_AFFINITY_AUTO` replaces `INTR_CPU_ID_AUTO`