### PR TITLE
Fix uninitialized members _pressed and _last_press in LGFX_Button for stable behavior

### DIFF
--- a/src/lgfx/v1/LGFX_Button.hpp
+++ b/src/lgfx/v1/LGFX_Button.hpp
@@ -90,7 +90,7 @@ namespace lgfx
     textdatum_t _textdatum = middle_center; // Text size multiplier and text datum for button
     char _label[12]; // Button text is 11 chars maximum unless long_name used
     float _textsize_x, _textsize_y;
-    bool _pressed, _last_press; // Button states
+    bool _pressed = false, _last_press = false; // Button states
   };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
In the LGFX_Button class, the boolean member variables `_pressed` and `_last_press` were left uninitialized. This led to undefined behavior, as the initial states of these variables were indeterminate upon the instantiation of LGFX_Button objects. Such undefined states can cause erratic and unpredictable behavior in the application, especially in features that rely on these variables to track the state and timing of certain actions.