### PR TITLE
Add argument to take QR code standard margin (QRコード標準の余白を確保する引数追加)

### DIFF
--- a/src/lgfx/v1/LGFXBase.cpp
+++ b/src/lgfx/v1/LGFXBase.cpp
@@ -2554,7 +2554,7 @@ namespace lgfx
 
 //----------------------------------------------------------------------------
 
-  void LGFXBase::qrcode(const char *string, int32_t x, int32_t y, int32_t w, uint8_t version) {
+  void LGFXBase::qrcode(const char *string, int32_t x, int32_t y, int32_t w, uint8_t version, bool margin) {
     if (w == -1) {
       w = std::min(width(), height()) * 9 / 10;
     }
@@ -2571,6 +2571,16 @@ namespace lgfx
       int_fast16_t thickness = w / qrcode.size;
       int_fast16_t lineLength = qrcode.size * thickness;
       int_fast16_t offset = (w - lineLength) >> 1;
+
+      if(margin) {
+        int_fast16_t mlen = thickness * 4; // Need 4 cell or greater margin
+        if(offset < mlen) {
+          thickness = (w - (mlen << 1)) / qrcode.size;
+          lineLength = qrcode.size * thickness;
+          offset = (w - lineLength) >> 1;
+        }
+      }
+
       startWrite();
       writeFillRect(x, y, w, offset, TFT_WHITE);
       int_fast16_t dy = y + offset;

--- a/src/lgfx/v1/LGFXBase.hpp
+++ b/src/lgfx/v1/LGFXBase.hpp
@@ -878,7 +878,7 @@ namespace lgfx
       qrcode(string.c_str(), x, y, width, version);
     }
 #endif
-    void qrcode(const char *string, int32_t x = -1, int32_t y = -1, int32_t width = -1, uint8_t version = 1);
+    void qrcode(const char *string, int32_t x = -1, int32_t y = -1, int32_t width = -1, uint8_t version = 1,bool margin = false);
 
   #define LGFX_FUNCTION_GENERATOR(drawImg, draw_img) \
    protected: \


### PR DESCRIPTION
### 修正点
QRコード規格では、コード周辺に 4 セル以上の余白が必要とされています。
参考: https://www.qrcode.com/howto/code.html

qrcode 関数に引数 bool mergin (default false) を追加し、旧来のコードに影響を与えず、マージンを追加する機構を追加しました。
 
```cpp
void qrcode(const char *string, int32_t x = -1, int32_t y = -1, int32_t width = -1, uint8_t version = 1, bool margin = false);
```
### 表示例
左:従来のもの 右:margin = true
青枠は qrcode による描画範囲
太さの減少によって 0 になった場合は、描画範囲が足りなかったときと同様に白塗り潰しとなります。

![qr_code_margin](https://github.com/user-attachments/assets/91e39ecc-2a5a-4400-a2fe-8e6bf9a658b6)
