### PR TITLE
Separate clear display from init function

### DIFF
--- a/src/lgfx/v1/LGFXBase.cpp
+++ b/src/lgfx/v1/LGFXBase.cpp
@@ -3516,6 +3516,10 @@ namespace lgfx
       }
       if (getPanel()->init(use_reset))
       {
+        if (use_clear)
+        {
+          getPanel()->clearDisplay();
+        }
         startWrite();
         invertDisplay(_panel->getInvert());
         setColorDepth(_panel->getWriteDepth());

--- a/src/lgfx/v1/LGFXBase.hpp
+++ b/src/lgfx/v1/LGFXBase.hpp
@@ -1409,6 +1409,7 @@ namespace lgfx
     bool init(void)               { return init_impl(true , true); };
     bool begin(void)              { return init_impl(true , true); };
     bool init_without_reset(void) { return init_impl(false, false); };
+    bool init_with_option(bool use_reset, bool use_clear) { return init_impl(use_reset, use_clear); };
     board_t getBoard(void) const { return _board; }
     void initBus(void);
     void releaseBus(void);

--- a/src/lgfx/v1/panel/Panel_Device.hpp
+++ b/src/lgfx/v1/panel/Panel_Device.hpp
@@ -112,6 +112,7 @@ namespace lgfx
     void config(const config_t& cfg) { _cfg = cfg; }
 
     virtual bool init(bool use_reset);
+    virtual bool clearDisplay() { return false; }
     virtual bool initTouch(void);
 
     virtual void initBus(void);

--- a/src/lgfx/v1/panel/Panel_EPDiy.cpp
+++ b/src/lgfx/v1/panel/Panel_EPDiy.cpp
@@ -67,6 +67,13 @@ namespace lgfx
     _buf = epd_hl_get_framebuffer(_config_detail.epd_hl);
     epd_poweron();
 
+    return true;
+  }
+
+  bool Panel_EPDiy::clearDisplay(void)
+  {
+    if(_buf == nullptr) return false;
+
     startWrite();
     memset(_buf, 0, _cfg.memory_width * _cfg.memory_height / 2);
     display(0, 0, _cfg.panel_width, _cfg.panel_height);

--- a/src/lgfx/v1/panel/Panel_EPDiy.hpp
+++ b/src/lgfx/v1/panel/Panel_EPDiy.hpp
@@ -53,6 +53,7 @@ namespace lgfx
 
     bool init(bool use_reset) override;
 
+    bool clearDisplay(void) override;
     void waitDisplay(void) override;
     bool displayBusy(void) override;
     color_depth_t setColorDepth(color_depth_t depth) override;


### PR DESCRIPTION
Proposal to separate clear display from init function.

This allows M5PaperS3 to power on from shutdown without the eInk display flickering.