### PR TITLE
Use actual glyph width, not the guessed spaceWidth, to determine the width of the space character in VLW fonts

### DIFF
--- a/src/lgfx/v1/lgfx_fonts.cpp
+++ b/src/lgfx/v1/lgfx_fonts.cpp
@@ -886,10 +886,7 @@ label_nextbyte: /// 次のデータを取得する;
     int32_t sy = 65536 * style->size_y;
     y += (metrics->y_offset * sy) >> 16;
 
-    if (code == 0x20) {
-      gNum = 0xFFFF;
-      buffer[2] = getSwap32(this->spaceWidth);
-    } else if (!this->getUnicodeIndex(code, &gNum)) {
+    if (!this->getUnicodeIndex(code, &gNum)) {
       return drawCharDummy(gfx, x, y, this->spaceWidth, metrics->height, style, filled_x);
     } else {
       file->preRead();

--- a/src/lgfx/v1/lgfx_fonts.cpp
+++ b/src/lgfx/v1/lgfx_fonts.cpp
@@ -887,7 +887,13 @@ label_nextbyte: /// 次のデータを取得する;
     y += (metrics->y_offset * sy) >> 16;
 
     if (!this->getUnicodeIndex(code, &gNum)) {
-      return drawCharDummy(gfx, x, y, this->spaceWidth, metrics->height, style, filled_x);
+      if (code != 0x20) {
+        return drawCharDummy(gfx, x, y, this->spaceWidth, metrics->height, style, filled_x);
+      }
+      // Some VLW exporters omit the space glyph; for such fonts, keep the
+      // guessed advance instead of rendering the missing-glyph box.
+      gNum = 0xFFFF;
+      buffer[2] = getSwap32(this->spaceWidth);
     } else {
       file->preRead();
       file->seek(28 + gNum * 28);


### PR DESCRIPTION
I was hitting an issue where `textWidth` would give me results that were slightly off from the actual width of a string drawn to the display when using a VLW font today. After a bunch of digging, it seems that the problem is that `drawChar` uses a special case for the space character where it uses `this->spaceWidth` (which according to the comment in the code is just a guess), instead of the width of the space glyph, but `textWidth` doesn't use this special case.

I'm not sure why this special case was there, and I'm not sure if this would break for some other fonts, but for my case at least the rendering looks correct, and textWidth and drawChar now agree.

Note: the test was done with a custom font, Bookerly 24pt, created using the M5 font converter
Also note: I pointed this at `develop` as that's what i'm using, let me know if that's wrong