### PR TITLE
Fix: disable data pins open drain mode to work on ESP-IDF v5.4 and above

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Bus_EPD.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_EPD.cpp
@@ -131,6 +131,11 @@ bool Bus_EPD::init(void)
   bus_config.bus_width = _config.bus_width;
   for (int i = 0; i < _config.bus_width; ++i) {
     bus_config.data_gpio_nums[i] = _config.pin_data[i];
+    // starting from ESP-IDF v5.4, esp_lcd_new_i80_bus removed `gpio_set_direction` call on all pins include these data pins,
+    // for somehow unknown reason, some of data pin like GPIO11, GPIO12 are Open-Drain mode when bootup and remains OD after
+    // `esp_lcd_new_i80_bus`, which will cause screen not works as expected.
+    // but on older IDF, those pins will disable OD in `gpio_set_direction`, so set these pin output and disable OD before `esp_lcd_new_i80_bus`
+    lgfx::pinMode(_config.pin_data[i], lgfx::pin_mode_t::output);
   }
   if (ESP_OK != esp_lcd_new_i80_bus(&bus_config, &_i80_bus_handle))
   { return false; }


### PR DESCRIPTION
This should fix #160 

For details about why see origin issue comment: https://github.com/m5stack/M5GFX/issues/160#issuecomment-3475139960