### PR TITLE
Fix std::min type mismatch for GCC 13+ compatibility

### DIFF
--- a/examples/Basic/AnalogMeter/AnalogMeter.ino
+++ b/examples/Basic/AnalogMeter/AnalogMeter.ino
@@ -165,7 +165,7 @@ void setup(void)
   needle_y = (meter_height*2 + display.width()) / 3;
   osx = needle_x;
   osy = needle_y;
-  liner_count = std::min(6, display.width() / 40);
+  liner_count = std::min<int>(6, display.width() / 40);
 
   analogMeter(); // Draw analogue meter
   int w = display.width() / liner_count;


### PR DESCRIPTION
### Summary

Fixes a compilation error caused by type mismatch in `std::min(int, long)` on newer toolchains (GCC 13+).  
This change ensures compatibility with modern ESP32 Arduino environments by explicitly specifying the template argument.

### Details

In environments using GCC 13 or later (e.g. ESP32 Arduino Core 3.x.x with xtensa-esp-elf-gcc 14.2.0), the following line fails to compile:

```
liner_count = std::min(6, display.width() / 40);
```

This is due to stricter template argument deduction rules in modern C++ compilers.  
To resolve this, the template argument is explicitly specified as `int`:

```
liner_count = std::min<int>(6, display.width() / 40);
```

This change preserves the original logic and ensures compatibility across toolchains.

### Tested Environment

- M5Stack Core2 v1.1
- Arduino IDE 2.3.6
- Board Manager: M5stack by M5Stack v3.2.3

---

### 概要

サンプルスケッチ"AnalogMeter.ino"のビルドでエラーが出たのでその修正です。GCC 13以降のツールチェインにおいて、`std::min(int, long)` の型不一致によりコンパイルエラーが発生する問題を修正しました。  
テンプレート引数を明示することで、最新のESP32 Arduino環境でも正常にビルドできるようになります。

### 修正内容

以下のコードは、型推論の厳格化によりエラーになります：

```
liner_count = std::min(6, display.width() / 40);
```

これを以下のように修正しました：

```
liner_count = std::min<int>(6, display.width() / 40);
```

これにより、型が一致してビルドできます。

### 動作確認環境

- M5Stack Core2 v1.1
- Arduino IDE 2.3.6
- Board Manager: M5stack by M5Stack v3.2.3
