### PR TITLE
fix(esp32-p4): Add type cast for MIPI_DSI_PHY_CLK_SRC_DEFAULT

### DIFF
--- a/src/lgfx/v1/platforms/esp32p4/Bus_DSI.cpp
+++ b/src/lgfx/v1/platforms/esp32p4/Bus_DSI.cpp
@@ -34,7 +34,7 @@ namespace lgfx
     esp_lcd_dsi_bus_config_t bus_config;
     bus_config.bus_id = _cfg.bus_id;
     bus_config.num_data_lanes = _cfg.lane_num;
-    bus_config.phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT;
+    bus_config.phy_clk_src = (mipi_dsi_phy_pllref_clock_source_t)MIPI_DSI_PHY_CLK_SRC_DEFAULT;
     bus_config.lane_bit_rate_mbps = _cfg.lane_mbps;
 
     esp_ldo_channel_config_t ldo_cfg;


### PR DESCRIPTION
Fixes compilation error on ESP32-P4 with Arduino ESP32 3.x framework. The macro MIPI_DSI_PHY_CLK_SRC_DEFAULT expands to soc_module_clk_t, but bus_config.phy_clk_src expects mipi_dsi_phy_pllref_clock_source_t.

This adds an explicit type cast to resolve the type mismatch.