### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ set(COMPONENT_ADD_INCLUDEDIRS
     )
 file(GLOB SRCS
      src/*.cpp
-     src/lgfx/Fonts/lvgl/lv_font_*.c
      src/lgfx/Fonts/efont/*.c
      src/lgfx/Fonts/IPA/*.c
+     src/lgfx/Fonts/lvgl/*.c
      src/lgfx/utility/*.c
      src/lgfx/v1/*.cpp
      src/lgfx/v1/lv_font/*.c

--- a/src/lgfx/utility/result.hpp
+++ b/src/lgfx/utility/result.hpp
@@ -4242,7 +4242,7 @@ auto RESULT_NS_IMPL::detail::throw_bad_result_access(E&& error) -> void
   std::abort();
 #else
   std::abort();
-/* // ESP32-S3向けビルドがコンパイルエラーとなるためコメントアウト by lovyan03; 
+/* // ESP32-S3向けビルドがコンパイルエラーとなるためコメントアウト by lovyan03;
   using exception_type = bad_result_access<
     typename std::remove_const<
       typename std::remove_reference<E>::type

--- a/src/lgfx/v1/LGFXBase.cpp
+++ b/src/lgfx/v1/LGFXBase.cpp
@@ -2059,47 +2059,48 @@ namespace lgfx
   uint16_t LGFXBase::decodeUTF8(uint8_t c)
   {
     // 7 bit Unicode Code Point
-    if (!(c & 0x80)) {
-      _decoderState = utf8_decode_state_t::utf8_state0;
-      return c;
-    }
-
-    if (_decoderState == utf8_decode_state_t::utf8_state0)
-    {
-      // 11 bit Unicode Code Point
-      if ((c & 0xE0) == 0xC0)
+    if ((c & 0x80)) {
+      // multibyte start or continue byte
+      switch (_decoderState)
       {
-        _unicode_buffer = ((c & 0x1F)<<6);
-        _decoderState = utf8_decode_state_t::utf8_state1;
-        return 0;
-      }
+        case utf8_decode_state_t::utf8_state3:
+        case utf8_decode_state_t::utf8_state2:
+        case utf8_decode_state_t::utf8_state1:
+            _decoderState=(utf8_decode_state_t)((uint8_t)_decoderState-1);
+            _unicode_buffer |= ((c & 0x3F) << (6 * (uint8_t)_decoderState));
+            return _decoderState ? 0 : _unicode_buffer;
 
-      // 16 bit Unicode Code Point
-      if ((c & 0xF0) == 0xE0)
-      {
-        _unicode_buffer = ((c & 0x0F)<<12);
-        _decoderState = utf8_decode_state_t::utf8_state2;
-        return 0;
-      }
-      // 21 bit Unicode  Code Point not supported so fall-back to extended ASCII
-      //if ((c & 0xF8) == 0xF0) return (uint16_t)c;
-    }
-    else
-    {
-      if (_decoderState == utf8_decode_state_t::utf8_state2)
-      {
-        _unicode_buffer |= ((c & 0x3F)<<6);
-        _decoderState = utf8_decode_state_t::utf8_state1;
-        return 0;
-      }
-      _unicode_buffer |= (c & 0x3F);
-      _decoderState = utf8_decode_state_t::utf8_state0;
-      return _unicode_buffer;
-    }
+        case utf8_decode_state_t::utf8_state0:
+        default:
+          // 11 bit Unicode Code Point
+          if ((c & 0xE0) == 0xC0)
+          {
+              _unicode_buffer = ((c & 0x1F) << (6 * 1));
+              _decoderState = utf8_decode_state_t::utf8_state1;
+              return 0;
+          }
 
+          // 16 bit Unicode Code Point
+          if ((c & 0xF0) == 0xE0)
+          {
+              _unicode_buffer = ((c & 0x0F) << (6 * 2));
+              _decoderState = utf8_decode_state_t::utf8_state2;
+              return 0;
+          }
+          // 21 bit Unicode  Code Point not supported so fall-back to extended ASCII
+          if ((c & 0xF8) == 0xF0)
+          {
+              _unicode_buffer = (c & 0x07)<<(6 * 3); // 6 bits for each of the 3 bytes
+              _decoderState = utf8_decode_state_t::utf8_state3;
+              return 0;
+          }
+          // fallback to extended ASCII
+          break;
+      }
+    }
+    // single byte ASCII
     _decoderState = utf8_decode_state_t::utf8_state0;
-
-    return c; // fall-back to extended ASCII
+    return c;
   }
 
   int32_t LGFXBase::fontHeight(const IFont* font) const

--- a/src/lgfx/v1/LGFXBase.cpp
+++ b/src/lgfx/v1/LGFXBase.cpp
@@ -1093,9 +1093,9 @@ namespace lgfx
       auto scanline = (rgb888_t*)alloca(w * sizeof(rgb888_t));
 
       startWrite();
-      for( int _y=0;_y<h;_y++ ) {
+      for( int _y=0;_y<(int)h;_y++ ) {
         // only half of the scan line needs to be calculated, the other half is mirrored
-        for( int _x=0;_x<=w/2;_x++ ) {
+        for( int _x=0;_x<=(int)w/2;_x++ ) {
           auto distance       = pixelDistance( fmidx, fmidy, _x*vratio, _y*hratio );
           scanline[_x]        = map_gradient( distance, 0, hyp0, gradient );
           scanline[(w-1)-_x]  = scanline[_x];
@@ -1118,11 +1118,11 @@ namespace lgfx
     bool is_vertical = style==VLINEAR;
     const uint32_t gradient_len = is_vertical ? h : w;
     auto scanline = (rgb888_t*)alloca(gradient_len * sizeof(rgb888_t));
-    for(int i=0;i<gradient_len;i++) { // memoize one gradient scanline
+    for(int i=0;i<(int)gradient_len;i++) { // memoize one gradient scanline
       scanline[i] = map_gradient( i, 0, gradient_len, gradient );
     }
     startWrite();
-    for( int ys=0;ys<h;ys++ ) {
+    for( int ys=0;ys<(int)h;ys++ ) {
       if( is_vertical ) { // scanline is used as an colors index
         setColor(color888(scanline[ys].r, scanline[ys].g, scanline[ys].b));
         drawFastHLine( x, y+ys, w );

--- a/src/lgfx/v1/LGFXBase.hpp
+++ b/src/lgfx/v1/LGFXBase.hpp
@@ -1022,6 +1022,7 @@ namespace lgfx
     { utf8_state0 = 0
     , utf8_state1 = 1
     , utf8_state2 = 2
+    , utf8_state3 = 3
     };
     utf8_decode_state_t _decoderState = utf8_state0;   // UTF8 decoder state
     uint16_t _unicode_buffer = 0;   // Unicode code-point buffer

--- a/src/lgfx/v1/lgfx_fonts.cpp
+++ b/src/lgfx/v1/lgfx_fonts.cpp
@@ -24,6 +24,9 @@
 #ifdef max
 #undef max
 #endif
+#ifdef abs
+#undef abs
+#endif
 
 namespace lgfx
 {
@@ -960,30 +963,20 @@ label_nextbyte: /// 次のデータを取得する;
     }
 
     uint8_t glyph_bpp = 8;
+    // NOTE: LV_FONT_GLYPH_FORMAT_* are enum values (see lv_font/font.h),
+    //       not preprocessor macros, so they cannot be #ifdef'd.
     switch (gd.format)
     {
-#ifdef LV_FONT_GLYPH_FORMAT_A1
       case LV_FONT_GLYPH_FORMAT_A1:
-#endif
-#ifdef LV_FONT_GLYPH_FORMAT_A1_ALIGNED
       case LV_FONT_GLYPH_FORMAT_A1_ALIGNED:
-#endif
         glyph_bpp = 1;
         break;
-#ifdef LV_FONT_GLYPH_FORMAT_A2
       case LV_FONT_GLYPH_FORMAT_A2:
-#endif
-#ifdef LV_FONT_GLYPH_FORMAT_A2_ALIGNED
       case LV_FONT_GLYPH_FORMAT_A2_ALIGNED:
-#endif
         glyph_bpp = 2;
         break;
-#ifdef LV_FONT_GLYPH_FORMAT_A4
       case LV_FONT_GLYPH_FORMAT_A4:
-#endif
-#ifdef LV_FONT_GLYPH_FORMAT_A4_ALIGNED
       case LV_FONT_GLYPH_FORMAT_A4_ALIGNED:
-#endif
         glyph_bpp = 4;
         break;
       default:

--- a/src/lgfx/v1/platforms/esp32/Bus_EPD.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_EPD.cpp
@@ -130,7 +130,7 @@ bool Bus_EPD::init(void)
   bus_config.wr_gpio_num = (gpio_num_t)_config.pin_cl;
   bus_config.bus_width = _config.bus_width;
   for (int i = 0; i < _config.bus_width; ++i) {
-    bus_config.data_gpio_nums[i] = _config.pin_data[i];
+    bus_config.data_gpio_nums[i] = (gpio_num_t)_config.pin_data[i];
     // starting from ESP-IDF v5.4, esp_lcd_new_i80_bus removed `gpio_set_direction` call on all pins include these data pins,
     // for somehow unknown reason, some of data pin like GPIO11, GPIO12 are Open-Drain mode when bootup and remains OD after
     // `esp_lcd_new_i80_bus`, which will cause screen not works as expected.

--- a/src/lgfx/v1/platforms/esp32/Bus_Parallel8.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_Parallel8.cpp
@@ -26,6 +26,14 @@ Contributors:
 #include <soc/i2s_struct.h>
 #include <rom/gpio.h>
 
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+ #define LGFX_GPIO_PAD_SELECT(pin)               rom_gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig, inv, oen_inv) rom_gpio_matrix_out((gpio_num_t)(pin), (sig), (inv), (oen_inv))
+#else
+ #define LGFX_GPIO_PAD_SELECT(pin)               gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig, inv, oen_inv) gpio_matrix_out((gpio_num_t)(pin), (sig), (inv), (oen_inv))
+#endif
+
 namespace lgfx
 {
  inline namespace v1
@@ -122,21 +130,21 @@ namespace lgfx
     {
       int32_t pin = _cfg.pin_data[i];
       if (pin < 0) { continue; }
-      gpio_pad_select_gpio(pin);
+      LGFX_GPIO_PAD_SELECT(pin);
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_INPUT_OUTPUT);
-      gpio_matrix_out(pin, idx_base + i, 0, 0);
+      LGFX_GPIO_MATRIX_OUT(pin, idx_base + i, 0, 0);
     }
 
     for (size_t i = 0; i < 3; ++i)
     {
       int32_t pin = _cfg.pin_ctrl[i];
       if (pin < 0) { continue; }
-      gpio_pad_select_gpio(pin);
+      LGFX_GPIO_PAD_SELECT(pin);
       gpio_hi(pin);
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_OUTPUT);
     }
 
-    gpio_matrix_out(_cfg.pin_rs, idx_base + 8, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, idx_base + 8, 0, 0);
 
     uint32_t dport_clk_en;
     uint32_t dport_rst;
@@ -154,7 +162,7 @@ namespace lgfx
       dport_rst = DPORT_I2S1_RST;
     }
 #endif
-    gpio_matrix_out(_cfg.pin_wr, idx_base, 1, 0); // WR (Write-strobe in 8080 mode, Active-low)
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_wr, idx_base, 1, 0); // WR (Write-strobe in 8080 mode, Active-low)
 
     DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, dport_clk_en);
     DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, dport_rst);
@@ -534,7 +542,7 @@ namespace lgfx
     if (_cache_index) { _cache_index = _flush(_cache_index, true); }
     _wait();
 
-    gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100, 0, 0);
     gpio_lo(_cfg.pin_rd);
   }
 
@@ -543,7 +551,7 @@ namespace lgfx
     gpio_hi(_cfg.pin_rd);
 
     auto idx_base = (_cfg.i2s_port == I2S_NUM_0) ? I2S0O_DATA_OUT16_IDX : I2S1O_DATA_OUT16_IDX;
-    gpio_matrix_out(_cfg.pin_rs, idx_base, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, idx_base, 0, 0);
   }
 
   void Bus_Parallel8::_read_bytes(uint8_t* __restrict dst, uint32_t length)

--- a/src/lgfx/v1/platforms/esp32/Bus_Parallel8.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_Parallel8.hpp
@@ -27,7 +27,9 @@ Contributors:
  #include <freertos/FreeRTOS.h>
 #endif
 
-#if __has_include(<driver/i2s_std.h>)
+#if __has_include(<driver/i2s_types.h>)
+ #include <driver/i2s_types.h>
+#elif __has_include(<driver/i2s_std.h>)
  #include <driver/i2s_std.h>
 #else
  #include <driver/i2s.h>

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
@@ -56,7 +56,7 @@ Contributors:
    #include <esp32/rom/gpio.h>
 #else
    #include <rom/gpio.h> // dispatched by core
-#endif   
+#endif
 
 #ifndef SPI_PIN_REG
  #define SPI_PIN_REG SPI_MISC_REG
@@ -68,6 +68,7 @@ Contributors:
   #include <soc/gdma_reg.h>
  #elif __has_include(<soc/axi_dma_reg.h>) // ESP32P4
   #include <soc/axi_dma_reg.h>
+  #include <esp_cache.h>
  #endif
  #if __has_include(<soc/gdma_struct.h>)
   #include <soc/gdma_struct.h>
@@ -189,6 +190,9 @@ namespace lgfx
     { // DMAチャンネルが特定できたらそれを使用する;
       _spi_dma_out_link_reg  = reg(DMA_OUT_LINK_CH0_REG       + assigned_dma_ch * SIZE_OF_DMA_OUT_CH);
       _spi_dma_outstatus_reg = reg(DMA_OUTFIFO_STATUS_CH0_REG + assigned_dma_ch * SIZE_OF_DMA_OUT_CH);
+      #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+      _spi_dma_out_link2_reg = reg(AXI_DMA_OUT_LINK2_CH0_REG  + assigned_dma_ch * SIZE_OF_DMA_OUT_CH);
+      #endif
     }
 #elif defined ( CONFIG_IDF_TARGET_ESP32 ) || !defined ( CONFIG_IDF_TARGET )
 
@@ -672,15 +676,28 @@ namespace lgfx
       if (use_dma)
       {
         auto spi_dma_out_link_reg = _spi_dma_out_link_reg;
+        #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+        auto spi_dma_out_link2_reg = _spi_dma_out_link2_reg;
+        #endif
         auto cmd = _spi_cmd_reg;
         while (*cmd & SPI_USR) {}
         *spi_dma_out_link_reg = 0;
         _setup_dma_desc_links(data, length);
+
+        #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+        esp_cache_msync((void*)data, sizeof(uint8_t) * length, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+        esp_cache_msync(_dmadesc, sizeof(lldesc_t) * _dmadesc_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+        #endif
 #if defined ( SOC_GDMA_SUPPORTED )
         auto dma = reg(SPI_DMA_CONF_REG(_spi_port));
         *dma = 0; /// Clear previous transfer
         uint32_t len = ((length - 1) & ((SPI_MS_DATA_BITLEN)>>3)) + 1;
+        #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+        *spi_dma_out_link2_reg = ((uint32_t)(_dmadesc));
+        *spi_dma_out_link_reg = DMA_OUTLINK_START_CH0 ;
+        #else
         *spi_dma_out_link_reg = DMA_OUTLINK_START_CH0 | ((int)(&_dmadesc[0]) & 0xFFFFF);
+        #endif
         *dma = SPI_DMA_TX_ENA;
         _clear_dma_reg = dma;
 #else
@@ -889,7 +906,12 @@ label_start:
     *_spi_dma_out_link_reg = 0;
 
 #if defined ( SOC_GDMA_SUPPORTED )
+    #if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+    *_spi_dma_out_link2_reg = ((uint32_t)(_dmadesc));
+    *_spi_dma_out_link_reg = DMA_OUTLINK_START_CH0;
+    #else
     *_spi_dma_out_link_reg = DMA_OUTLINK_START_CH0 | ((int)(&_dmadesc[0]) & 0xFFFFF);
+    #endif
     auto dma = reg(SPI_DMA_CONF_REG(_spi_port));
     *dma = SPI_DMA_TX_ENA;
     _clear_dma_reg = dma;

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
@@ -18,6 +18,11 @@ Contributors:
 #if defined (ESP_PLATFORM)
 #include <sdkconfig.h>
 
+#if defined (CONFIG_IDF_TARGET_ESP32P4)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 #include "Bus_SPI.hpp"
 
 #if defined ( CONFIG_IDF_TARGET_ESP32 ) || !defined ( CONFIG_IDF_TARGET )
@@ -63,7 +68,14 @@ Contributors:
 #endif
 
 #if defined (SOC_GDMA_SUPPORTED)  // for C3/C6/S3
- #include <soc/gdma_channel.h>
+ #if __has_include(<soc/gdma_channel.h>)
+  #include <soc/gdma_channel.h>
+ #elif __has_include(<hal/gdma_channel.h>)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wattributes"
+  #include <hal/gdma_channel.h>
+  #pragma GCC diagnostic pop
+ #endif
  #if __has_include(<soc/gdma_reg.h>)
   #include <soc/gdma_reg.h>
  #elif __has_include(<soc/axi_dma_reg.h>) // ESP32P4
@@ -96,7 +108,15 @@ Contributors:
  #endif
 #endif
 
+#if !defined(gpio_matrix_out) && defined(rom_gpio_matrix_out)
+ #define gpio_matrix_out rom_gpio_matrix_out
+#endif
+
 #include "common.hpp"
+
+#if defined (CONFIG_IDF_TARGET_ESP32P4)
+ #pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 
@@ -210,7 +230,11 @@ namespace lgfx
   {
     if (pin >= GPIO_NUM_MAX) return;
     gpio_reset_pin( (gpio_num_t)pin);
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+    rom_gpio_matrix_out((gpio_num_t)pin, SIG_GPIO_OUT_IDX, 0, 0);
+#else
     gpio_matrix_out((gpio_num_t)pin, SIG_GPIO_OUT_IDX, 0, 0);
+#endif
     // gpio_matrix_in には、ArduinoESP32 v1.0.x系では重大なバグがある。(無関係なピンに対して設定変更が行われることがある)
     // gpio_matrix_in( (gpio_num_t)pin, 0x100, 0   );
   }
@@ -1195,7 +1219,18 @@ label_start:
       periph_module_reset( PERIPH_SPI3_DMA_MODULE );
     }
 #elif defined( CONFIG_IDF_TARGET_ESP32 ) || !defined( CONFIG_IDF_TARGET )
+ #if defined (PERIPH_SPI_DMA_MODULE)
     periph_module_reset( PERIPH_SPI_DMA_MODULE );
+ #elif defined (PERIPH_HSPI_MODULE) && defined (PERIPH_VSPI_MODULE)
+    if (_cfg.spi_host == SPI2_HOST)
+    {
+      periph_module_reset( PERIPH_HSPI_MODULE );
+    }
+    else
+    {
+      periph_module_reset( PERIPH_VSPI_MODULE );
+    }
+ #endif
 #endif
   }
 

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
@@ -186,6 +186,9 @@ namespace lgfx
     volatile uint32_t* _spi_cmd_reg = nullptr;
     volatile uint32_t* _spi_user_reg = nullptr;
     volatile uint32_t* _spi_dma_out_link_reg = nullptr;
+    #if defined (CONFIG_IDF_TARGET_ESP32P4)
+    volatile uint32_t* _spi_dma_out_link2_reg = nullptr;
+    #endif
     volatile uint32_t* _spi_dma_outstatus_reg = nullptr;
     volatile uint32_t* _clear_dma_reg = nullptr;
     uint32_t _last_freq_apb = 0;

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
@@ -90,7 +90,13 @@ namespace lgfx
       bool use_lock = true;
       uint8_t dma_channel = LGFX_ESP32_SPI_DMA_CH;
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
-      spi_host_device_t spi_host = VSPI_HOST;
+     #if defined (VSPI_HOST)
+       spi_host_device_t spi_host = VSPI_HOST;
+     #elif defined (SPI3_HOST)
+       spi_host_device_t spi_host = SPI3_HOST;
+     #else
+       spi_host_device_t spi_host = SPI2_HOST;
+     #endif
 #else
       spi_host_device_t spi_host = SPI2_HOST;
 #endif

--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -26,6 +26,7 @@ Contributors:
   #include <esp_arduino_version.h>
  #endif
 #else
+ #include <driver/gpio.h>
  #include <driver/ledc.h>
 #endif
 
@@ -46,11 +47,14 @@ namespace lgfx
 #if defined ESP_ARDUINO_VERSION
   #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
     #define LEDC_USE_IDF_V5 // esp32-arduino core 3.x.x uses the new ledC syntax
-  #endif   
+  #endif
+  #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(6, 0, 0)
+    #define LEDC_USE_IDF_V6 // esp32-arduino core 6.x.x
+  #endif
 #endif
 
 #if defined LEDC_USE_IDF_V5
-    ledcAttach(_cfg.pin_bl, _cfg.freq, PWM_BITS); 
+    ledcAttach(_cfg.pin_bl, _cfg.freq, PWM_BITS);
     setBrightness(brightness);
 #else
     ledcSetup(_cfg.pwm_channel, _cfg.freq, PWM_BITS);
@@ -68,7 +72,9 @@ namespace lgfx
      ledc_channel.speed_mode = LEDC_LOW_SPEED_MODE;
 #endif
      ledc_channel.channel    = (ledc_channel_t)_cfg.pwm_channel;
+#if !defined LEDC_USE_IDF_V6  // ledc_channel_config_t.intr_type is deprecated, no need to explicitly configure interrupt, handled in the driver
      ledc_channel.intr_type  = LEDC_INTR_DISABLE;
+#endif
      ledc_channel.timer_sel  = (ledc_timer_t)((_cfg.pwm_channel >> 1) & 3);
      ledc_channel.duty       = _cfg.invert ? (1 << PWM_BITS) : 0;
      ledc_channel.hpoint     = 0;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -43,7 +43,7 @@ Contributors:
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
  #if __has_include(<hal/i2c_ll.h>)
   #include <hal/i2c_ll.h>
-  #if defined ( i2c_ll_reset_register )
+  #if defined ( i2c_ll_reset_register ) || (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
    #if SOC_PERIPH_CLK_CTRL_SHARED
     #define I2C_CLOCK_SRC_ATOMIC() PERIPH_RCC_ATOMIC()
    #else
@@ -129,6 +129,9 @@ Contributors:
 #endif
 
 #if defined (SOC_GDMA_SUPPORTED)  // for C3/S3
+ #if __has_include(<hal/gdma_ll.h>)
+  #include <hal/gdma_ll.h>
+ #endif
  #if __has_include(<soc/gdma_reg.h>)
   #include <soc/gdma_reg.h>
  #elif __has_include(<soc/axi_dma_reg.h>) // ESP32P4
@@ -153,7 +156,13 @@ Contributors:
  #endif
 
  #if !defined (SOC_GDMA_PAIRS_PER_GROUP_MAX)
-  #define SOC_GDMA_PAIRS_PER_GROUP_MAX SOC_GDMA_PAIRS_PER_GROUP
+  #if defined (SOC_GDMA_PAIRS_PER_GROUP)
+   #define SOC_GDMA_PAIRS_PER_GROUP_MAX SOC_GDMA_PAIRS_PER_GROUP
+  #elif defined (GDMA_LL_PAIRS_PER_INST)
+   #define SOC_GDMA_PAIRS_PER_GROUP_MAX GDMA_LL_PAIRS_PER_INST
+  #else
+   #define SOC_GDMA_PAIRS_PER_GROUP_MAX 5
+  #endif
  #endif
 #endif
 
@@ -547,7 +556,13 @@ namespace lgfx
 #endif
 
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
-    static constexpr int default_spi_host = VSPI_HOST;
+ #if defined (VSPI_HOST)
+   static constexpr int default_spi_host = VSPI_HOST;
+ #elif defined (SPI3_HOST)
+   static constexpr int default_spi_host = SPI3_HOST;
+ #else
+   static constexpr int default_spi_host = SPI2_HOST;
+ #endif
     static constexpr int spi_periph_num = 3;
 #else
     static constexpr int default_spi_host = SPI2_HOST;
@@ -867,8 +882,15 @@ namespace lgfx
  #define I2C_ACK_ERR_INT_RAW_M I2C_NACK_INT_RAW_M
 #endif
 
+#if !defined ( I2C_CLOCK_SRC_ATOMIC )
+  #if __cplusplus <= 201103L
+    #define LGFX_PERIPH_MODULE_T periph_module_t
+  #else
+    #define LGFX_PERIPH_MODULE_T auto
+  #endif
+
     __attribute__ ((unused))
-    static periph_module_t getPeriphModule(int num)
+        static LGFX_PERIPH_MODULE_T getPeriphModule(int num)
     {
 #if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C6
       return PERIPH_I2C0_MODULE;
@@ -876,6 +898,9 @@ namespace lgfx
       return num == 0 ? PERIPH_I2C0_MODULE : PERIPH_I2C1_MODULE;
 #endif
     }
+
+  #undef LGFX_PERIPH_MODULE_T
+#endif
 
     static i2c_dev_t* getDev(int num)
     {
@@ -1091,7 +1116,11 @@ namespace lgfx
 #if __has_include(<driver/i2c_master.h>)
       if ((int8_t)pin_sda >= 0) {
         gpio_set_level(pin_sda, true);
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+        (void)gpio_iomux_output(pin_sda, PIN_FUNC_GPIO);
+#else
         gpio_iomux_out(pin_sda, PIN_FUNC_GPIO, false);
+#endif
         gpio_set_direction(pin_sda, GPIO_MODE_INPUT_OUTPUT_OD);
         gpio_set_pull_mode(pin_sda, GPIO_PULLUP_ONLY);
         esp_rom_gpio_connect_out_signal(pin_sda, i2c_periph_signal[i2c_num].sda_out_sig, 0, 0);
@@ -1099,7 +1128,11 @@ namespace lgfx
       }
       if ((int8_t)pin_scl >= 0) {
         gpio_set_level(pin_scl, true);
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+        (void)gpio_iomux_output(pin_scl, PIN_FUNC_GPIO);
+#else
         gpio_iomux_out(pin_scl, PIN_FUNC_GPIO, false);
+#endif
         gpio_set_direction(pin_scl, GPIO_MODE_INPUT_OUTPUT_OD);
         esp_rom_gpio_connect_out_signal(pin_scl, i2c_periph_signal[i2c_num].scl_out_sig, 0, 0);
         esp_rom_gpio_connect_in_signal(pin_scl, i2c_periph_signal[i2c_num].scl_in_sig, 0);

--- a/src/lgfx/v1/platforms/esp32/common.hpp
+++ b/src/lgfx/v1/platforms/esp32/common.hpp
@@ -31,6 +31,8 @@ Contributors:
 #include <soc/spi_reg.h>
 #if __has_include(<soc/i2s_reg.h>)
 #include <soc/i2s_reg.h>
+#include <soc/gpio_reg.h>
+#include <soc/gpio_periph.h>
 #endif
 #include <soc/gpio_struct.h>
 #include <soc/gpio_sig_map.h>
@@ -90,6 +92,13 @@ Contributors:
 #if defined ( ESP_IDF_VERSION_VAL )
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
   #define LGFX_IDF_V5
+ #endif
+
+ #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  #ifndef LGFX_I2S_PORT_T_COMPAT
+   #define LGFX_I2S_PORT_T_COMPAT 1
+   typedef int i2s_port_t;
+  #endif
  #endif
 
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)

--- a/src/lgfx/v1/platforms/esp32c3/Bus_Parallel8.cpp
+++ b/src/lgfx/v1/platforms/esp32c3/Bus_Parallel8.cpp
@@ -25,6 +25,12 @@ Contributors:
 #include <rom/gpio.h>
 #include <hal/gpio_ll.h>
 
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+ #define LGFX_GPIO_PAD_SELECT(pin) rom_gpio_pad_select_gpio((gpio_num_t)(pin))
+#else
+ #define LGFX_GPIO_PAD_SELECT(pin) gpio_pad_select_gpio((gpio_num_t)(pin))
+#endif
+
 namespace lgfx
 {
  inline namespace v1
@@ -64,9 +70,9 @@ namespace lgfx
 
     _init_pin();
 
-    gpio_pad_select_gpio(_cfg.pin_rd);
-    gpio_pad_select_gpio(_cfg.pin_wr);
-    gpio_pad_select_gpio(_cfg.pin_rs);
+    LGFX_GPIO_PAD_SELECT(_cfg.pin_rd);
+    LGFX_GPIO_PAD_SELECT(_cfg.pin_wr);
+    LGFX_GPIO_PAD_SELECT(_cfg.pin_rs);
 
     gpio_hi(_cfg.pin_rd);
     gpio_hi(_cfg.pin_wr);
@@ -85,7 +91,7 @@ namespace lgfx
     gpio_mode_t gpio_mode = read ? GPIO_MODE_INPUT : GPIO_MODE_OUTPUT;
     for (size_t i = 0; i < 8; ++i)
     {
-      gpio_pad_select_gpio(pins[i]);
+      LGFX_GPIO_PAD_SELECT(pins[i]);
       gpio_set_direction((gpio_num_t)pins[i], gpio_mode);
     }
   }

--- a/src/lgfx/v1/platforms/esp32p4/Panel_DSI.cpp
+++ b/src/lgfx/v1/platforms/esp32p4/Panel_DSI.cpp
@@ -24,6 +24,9 @@ Contributors:
 
 #include <esp_lcd_panel_ops.h>
 #include <esp_lcd_panel_io.h>
+#if __has_include(<esp_idf_version.h>)
+ #include <esp_idf_version.h>
+#endif
 
 namespace lgfx
 {
@@ -73,7 +76,12 @@ namespace lgfx
     dpi_config.virtual_channel = 0;
     dpi_config.dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT;
     dpi_config.dpi_clock_freq_mhz = _config_detail.dpi_freq_mhz;
+  #if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+    dpi_config.in_color_format = LCD_COLOR_FMT_RGB565;
+    dpi_config.out_color_format = LCD_COLOR_FMT_RGB565;
+  #else
     dpi_config.pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565;
+  #endif
     dpi_config.num_fbs = 1;
     dpi_config.video_timing.h_size = _cfg.panel_width;
     dpi_config.video_timing.v_size = _cfg.panel_height;
@@ -83,9 +91,17 @@ namespace lgfx
     dpi_config.video_timing.vsync_back_porch  = _config_detail.vsync_back_porch;
     dpi_config.video_timing.vsync_pulse_width = _config_detail.vsync_pulse_width;
     dpi_config.video_timing.vsync_front_porch = _config_detail.vsync_front_porch;
+  #if !defined (ESP_IDF_VERSION_VAL) || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0))
     dpi_config.flags.use_dma2d = true;
-
-    return ESP_OK == esp_lcd_new_panel_dpi(mipi_dsi_bus, &dpi_config, &_disp_panel_handle);
+  #endif
+    auto ret = esp_lcd_new_panel_dpi(mipi_dsi_bus, &dpi_config, &_disp_panel_handle);
+  #if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+    if (ret == ESP_OK)
+    {
+      (void)esp_lcd_dpi_panel_enable_dma2d(_disp_panel_handle);
+    }
+  #endif
+    return ret == ESP_OK;
   }
 
   color_depth_t Panel_DSI::setColorDepth(color_depth_t depth)

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.cpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.cpp
@@ -27,6 +27,21 @@ Contributors:
 #include <hal/gpio_ll.h>
 #include <esp_log.h>
 
+#if !defined (DPORT_PERIP_CLK_EN_REG) && defined (DPORT_PERIP_CLK_EN0_REG)
+ #define DPORT_PERIP_CLK_EN_REG DPORT_PERIP_CLK_EN0_REG
+#endif
+#if !defined (DPORT_PERIP_RST_EN_REG) && defined (DPORT_PERIP_RST_EN0_REG)
+ #define DPORT_PERIP_RST_EN_REG DPORT_PERIP_RST_EN0_REG
+#endif
+
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+ #define LGFX_GPIO_PAD_SELECT(pin)               rom_gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig, inv, oen_inv) rom_gpio_matrix_out((gpio_num_t)(pin), (sig), (inv), (oen_inv))
+#else
+ #define LGFX_GPIO_PAD_SELECT(pin)               gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig, inv, oen_inv) gpio_matrix_out((gpio_num_t)(pin), (sig), (inv), (oen_inv))
+#endif
+
 namespace lgfx
 {
  inline namespace v1
@@ -87,14 +102,14 @@ namespace lgfx
     {
       int32_t pin = _cfg.pin_ctrl[i];
       if (pin < 0) { continue; }
-      gpio_pad_select_gpio(pin);
+      LGFX_GPIO_PAD_SELECT(pin);
       gpio_hi(pin);
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_OUTPUT);
     }
 
     auto idx_base = I2S0O_DATA_OUT8_IDX;
 
-    gpio_matrix_out(_cfg.pin_rs , I2S0O_DATA_OUT0_IDX, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs , I2S0O_DATA_OUT0_IDX, 0, 0);
 
     _direct_dc = false;
 
@@ -114,7 +129,7 @@ namespace lgfx
       dport_rst = DPORT_I2S1_RST;
     }
 #endif
-    gpio_matrix_out(_cfg.pin_wr, idx_base, 1, 0); // WR (Write-strobe in 8080 mode, Active-low)
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_wr, idx_base, 1, 0); // WR (Write-strobe in 8080 mode, Active-low)
 
     DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, dport_clk_en);
     DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, dport_rst);
@@ -163,10 +178,10 @@ namespace lgfx
       for (size_t i = 0; i < 8; ++i)
       {
         // gpio_set_direction((gpio_num_t)pins[i], GPIO_MODE_INPUT_OUTPUT);
-        gpio_pad_select_gpio(pins[i  ]);
-        gpio_pad_select_gpio(pins[i+8]);
-        gpio_matrix_out(pins[i  ], I2S0O_DATA_OUT8_IDX + i+8, 0, 0);
-        gpio_matrix_out(pins[i+8], I2S0O_DATA_OUT8_IDX + i  , 0, 0);
+        LGFX_GPIO_PAD_SELECT(pins[i  ]);
+        LGFX_GPIO_PAD_SELECT(pins[i+8]);
+        LGFX_GPIO_MATRIX_OUT(pins[i  ], I2S0O_DATA_OUT8_IDX + i+8, 0, 0);
+        LGFX_GPIO_MATRIX_OUT(pins[i+8], I2S0O_DATA_OUT8_IDX + i  , 0, 0);
       }
     }
   }
@@ -280,7 +295,7 @@ namespace lgfx
     if (_direct_dc)
     {
       _direct_dc = false;
-      gpio_matrix_out(_cfg.pin_rs, I2S0O_DATA_OUT0_IDX, 0, 0);
+      LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, I2S0O_DATA_OUT0_IDX, 0, 0);
       wait -= 16;
     }
     if (wait > 0)
@@ -536,7 +551,7 @@ namespace lgfx
         if (!_direct_dc)
         {
           _direct_dc = true;
-          gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+          LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100, 0, 0);
           wait -= 16;
         }
         if (wait > 0)
@@ -561,7 +576,7 @@ namespace lgfx
     if (!_direct_dc)
     {
       _direct_dc = true;
-      gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+      LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100, 0, 0);
     }
     gpio_lo(_cfg.pin_rd);
 

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.hpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.hpp
@@ -27,7 +27,9 @@ Contributors:
  #include <freertos/FreeRTOS.h>
 #endif
 
-#if __has_include(<driver/i2s_std.h>)
+#if __has_include(<driver/i2s_types.h>)
+ #include <driver/i2s_types.h>
+#elif __has_include(<driver/i2s_std.h>)
  #include <driver/i2s_std.h>
 #else
  #include <driver/i2s.h>

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.cpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.cpp
@@ -27,6 +27,21 @@ Contributors:
 #include <hal/gpio_ll.h>
 #include <esp_log.h>
 
+#if !defined (DPORT_PERIP_CLK_EN_REG) && defined (DPORT_PERIP_CLK_EN0_REG)
+ #define DPORT_PERIP_CLK_EN_REG DPORT_PERIP_CLK_EN0_REG
+#endif
+#if !defined (DPORT_PERIP_RST_EN_REG) && defined (DPORT_PERIP_RST_EN0_REG)
+ #define DPORT_PERIP_RST_EN_REG DPORT_PERIP_RST_EN0_REG
+#endif
+
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+ #define LGFX_GPIO_PAD_SELECT(pin)               rom_gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig, inv, oen_inv) rom_gpio_matrix_out((gpio_num_t)(pin), (sig), (inv), (oen_inv))
+#else
+ #define LGFX_GPIO_PAD_SELECT(pin)               gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig, inv, oen_inv) gpio_matrix_out((gpio_num_t)(pin), (sig), (inv), (oen_inv))
+#endif
+
 namespace lgfx
 {
  inline namespace v1
@@ -87,14 +102,14 @@ namespace lgfx
     {
       int32_t pin = _cfg.pin_ctrl[i];
       if (pin < 0) { continue; }
-      gpio_pad_select_gpio(pin);
+      LGFX_GPIO_PAD_SELECT(pin);
       gpio_hi(pin);
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_OUTPUT);
     }
 
     auto idx_base = I2S0O_DATA_OUT15_IDX;
 
-    gpio_matrix_out(_cfg.pin_rs, idx_base    , 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, idx_base    , 0, 0);
 
     _direct_dc = false;
 
@@ -114,7 +129,7 @@ namespace lgfx
       dport_rst = DPORT_I2S1_RST;
     }
 #endif
-    gpio_matrix_out(_cfg.pin_wr, idx_base, 1, 0); // WR (Write-strobe in 8080 mode, Active-low)
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_wr, idx_base, 1, 0); // WR (Write-strobe in 8080 mode, Active-low)
 
     DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, dport_clk_en);
     DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, dport_rst);
@@ -164,8 +179,8 @@ namespace lgfx
       for (size_t i = 0; i < 8; ++i)
       {
         // gpio_set_direction((gpio_num_t)pins[i], GPIO_MODE_INPUT_OUTPUT);
-        gpio_pad_select_gpio(pins[i]);
-        gpio_matrix_out(pins[i], idx_base + i, 0, 0);
+        LGFX_GPIO_PAD_SELECT(pins[i]);
+        LGFX_GPIO_MATRIX_OUT(pins[i], idx_base + i, 0, 0);
       }
     }
   }
@@ -280,7 +295,7 @@ namespace lgfx
     {
       _direct_dc = false;
       auto idx_base = I2S0O_DATA_OUT15_IDX;
-      gpio_matrix_out(_cfg.pin_rs, idx_base, 0, 0);
+      LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, idx_base, 0, 0);
     }
     else if (_div_num < 4)
     { /// OUTLINK_START～TX_STARTの時間が短すぎるとデータの先頭を送り損じる事があるのでnopウェイトを入れる;
@@ -449,7 +464,7 @@ namespace lgfx
       if (!_direct_dc)
       {
         _direct_dc = true;
-        gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+        LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100, 0, 0);
       }
       else
       {
@@ -471,7 +486,7 @@ namespace lgfx
     if (!_direct_dc)
     {
       _direct_dc = true;
-      gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+      LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100, 0, 0);
     }
     gpio_lo(_cfg.pin_rd);
 

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.hpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.hpp
@@ -27,7 +27,9 @@ Contributors:
  #include <freertos/FreeRTOS.h>
 #endif
 
-#if __has_include(<driver/i2s_std.h>)
+#if __has_include(<driver/i2s_types.h>)
+ #include <driver/i2s_types.h>
+#elif __has_include(<driver/i2s_std.h>)
  #include <driver/i2s_std.h>
 #else
  #include <driver/i2s.h>

--- a/src/lgfx/v1/platforms/esp32s3/Bus_Parallel16.cpp
+++ b/src/lgfx/v1/platforms/esp32s3/Bus_Parallel16.cpp
@@ -31,13 +31,25 @@ Contributors:
 #include <soc/lcd_cam_reg.h>
 #include <soc/lcd_cam_struct.h>
 
-#include <soc/gdma_channel.h>
+#if __has_include(<soc/gdma_channel.h>)
+ #include <soc/gdma_channel.h>
+#elif __has_include(<hal/gdma_channel.h>)
+ #include <hal/gdma_channel.h>
+#endif
 #include <soc/gdma_reg.h>
 #if !defined (DMA_OUT_LINK_CH0_REG)
   #define DMA_OUT_LINK_CH0_REG       GDMA_OUT_LINK_CH0_REG
   #define DMA_OUTFIFO_STATUS_CH0_REG GDMA_OUTFIFO_STATUS_CH0_REG
   #define DMA_OUTLINK_START_CH0      GDMA_OUTLINK_START_CH0
   #define DMA_OUTFIFO_EMPTY_CH0      GDMA_OUTFIFO_EMPTY_L3_CH0
+#endif
+
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+ #define LGFX_GPIO_PAD_SELECT(pin)      rom_gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig) rom_gpio_matrix_out((gpio_num_t)(pin), (sig), 0, 0)
+#else
+ #define LGFX_GPIO_PAD_SELECT(pin)      gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig) gpio_matrix_out((gpio_num_t)(pin), (sig), 0, 0)
 #endif
 
 #if ( ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0) )
@@ -74,23 +86,23 @@ namespace lgfx
     {
       int32_t pin = _cfg.pin_ctrl[i];
       if (pin < 0) { continue; }
-      gpio_pad_select_gpio(pin);
+      LGFX_GPIO_PAD_SELECT(pin);
       gpio_hi(pin);
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_OUTPUT);
     }
 
-    gpio_matrix_out(_cfg.pin_rs, LCD_DC_IDX, 0, 0);
-    gpio_matrix_out(_cfg.pin_wr, LCD_PCLK_IDX, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, LCD_DC_IDX);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_wr, LCD_PCLK_IDX);
 
     esp_lcd_i80_bus_config_t bus_config;
     memset(&bus_config, 0, sizeof(esp_lcd_i80_bus_config_t));
     bus_config.clk_src = lcd_clock_source_t::LCD_CLK_SRC_PLL160M; // IDFのバージョンによってenumの値が異なるので注意
-    bus_config.dc_gpio_num = _cfg.pin_rs;
-    bus_config.wr_gpio_num = _cfg.pin_wr;
+    bus_config.dc_gpio_num = (gpio_num_t)_cfg.pin_rs;
+    bus_config.wr_gpio_num = (gpio_num_t)_cfg.pin_wr;
     for (int i = 0; i < 8; ++i)
     {
-      bus_config.data_gpio_nums[i  ] = _cfg.pin_data[i+8];
-      bus_config.data_gpio_nums[i+8] = _cfg.pin_data[i  ];
+      bus_config.data_gpio_nums[i  ] = (gpio_num_t)_cfg.pin_data[i+8];
+      bus_config.data_gpio_nums[i+8] = (gpio_num_t)_cfg.pin_data[i  ];
     }
     bus_config.bus_width = 16;
     bus_config.max_transfer_bytes = 4092;
@@ -148,8 +160,8 @@ namespace lgfx
       auto idx_base = LCD_DATA_OUT0_IDX;
       for (size_t i = 0; i < 8; ++i)
       {
-        gpio_matrix_out(pins[i]  , idx_base + i+8, 0, 0);
-        gpio_matrix_out(pins[i+8], idx_base + i  , 0, 0);
+        LGFX_GPIO_MATRIX_OUT(pins[i]  , idx_base + i+8);
+        LGFX_GPIO_MATRIX_OUT(pins[i+8], idx_base + i  );
       }
     }
   }
@@ -435,7 +447,7 @@ namespace lgfx
     if (_has_align_data) { _send_align_data(); }
     wait();
     _init_pin(true);
-    gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100);
     gpio_lo(_cfg.pin_rd);
   }
 
@@ -443,7 +455,7 @@ namespace lgfx
   {
     gpio_hi(_cfg.pin_rd);
     _init_pin();
-    gpio_matrix_out(_cfg.pin_rs, LCD_DC_IDX, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, LCD_DC_IDX);
   }
 
   void Bus_Parallel16::_read_bytes(uint8_t* dst, uint32_t length)

--- a/src/lgfx/v1/platforms/esp32s3/Bus_Parallel8.cpp
+++ b/src/lgfx/v1/platforms/esp32s3/Bus_Parallel8.cpp
@@ -31,13 +31,25 @@ Contributors:
 #include <soc/lcd_cam_reg.h>
 #include <soc/lcd_cam_struct.h>
 
-#include <soc/gdma_channel.h>
+#if __has_include(<soc/gdma_channel.h>)
+ #include <soc/gdma_channel.h>
+#elif __has_include(<hal/gdma_channel.h>)
+ #include <hal/gdma_channel.h>
+#endif
 #include <soc/gdma_reg.h>
 #if !defined (DMA_OUT_LINK_CH0_REG)
   #define DMA_OUT_LINK_CH0_REG       GDMA_OUT_LINK_CH0_REG
   #define DMA_OUTFIFO_STATUS_CH0_REG GDMA_OUTFIFO_STATUS_CH0_REG
   #define DMA_OUTLINK_START_CH0      GDMA_OUTLINK_START_CH0
   #define DMA_OUTFIFO_EMPTY_CH0      GDMA_OUTFIFO_EMPTY_L3_CH0
+#endif
+
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+ #define LGFX_GPIO_PAD_SELECT(pin)      rom_gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig) rom_gpio_matrix_out((gpio_num_t)(pin), (sig), 0, 0)
+#else
+ #define LGFX_GPIO_PAD_SELECT(pin)      gpio_pad_select_gpio((gpio_num_t)(pin))
+ #define LGFX_GPIO_MATRIX_OUT(pin, sig) gpio_matrix_out((gpio_num_t)(pin), (sig), 0, 0)
 #endif
 
 #if ( ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0) )
@@ -74,23 +86,23 @@ namespace lgfx
     {
       int32_t pin = _cfg.pin_ctrl[i];
       if (pin < 0) { continue; }
-      gpio_pad_select_gpio(pin);
+      LGFX_GPIO_PAD_SELECT(pin);
       gpio_hi(pin);
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_OUTPUT);
     }
 
-    gpio_matrix_out(_cfg.pin_rs, LCD_DC_IDX, 0, 0);
-    gpio_matrix_out(_cfg.pin_wr, LCD_PCLK_IDX, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, LCD_DC_IDX);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_wr, LCD_PCLK_IDX);
 
     esp_lcd_i80_bus_config_t bus_config;
     memset(&bus_config, 0, sizeof(esp_lcd_i80_bus_config_t));
     bus_config.clk_src = lcd_clock_source_t::LCD_CLK_SRC_PLL160M; // IDFのバージョンによってenumの値が異なるので注意
-    bus_config.dc_gpio_num = _cfg.pin_rs;
-    bus_config.wr_gpio_num = _cfg.pin_wr;
+    bus_config.dc_gpio_num = (gpio_num_t)_cfg.pin_rs;
+    bus_config.wr_gpio_num = (gpio_num_t)_cfg.pin_wr;
     for (int i = 0; i < 8; ++i)
     {
-      bus_config.data_gpio_nums[i] = _cfg.pin_data[i];
-      bus_config.data_gpio_nums[i+8] = -1;
+      bus_config.data_gpio_nums[i] = (gpio_num_t)_cfg.pin_data[i];
+      bus_config.data_gpio_nums[i+8] = (gpio_num_t)-1;
     }
     bus_config.bus_width = 8;
     bus_config.max_transfer_bytes = 4092;
@@ -148,7 +160,7 @@ namespace lgfx
       auto idx_base = LCD_DATA_OUT0_IDX;
       for (size_t i = 0; i < 8; ++i)
       {
-        gpio_matrix_out(pins[i], idx_base + i, 0, 0);
+        LGFX_GPIO_MATRIX_OUT(pins[i], idx_base + i);
       }
     }
   }
@@ -393,14 +405,14 @@ namespace lgfx
     wait();
     _init_pin(true);
     gpio_lo(_cfg.pin_rd);
-    gpio_matrix_out(_cfg.pin_rs, 0x100, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, 0x100);
   }
 
   void Bus_Parallel8::endRead(void)
   {
     gpio_hi(_cfg.pin_rd);
     _init_pin();
-    gpio_matrix_out(_cfg.pin_rs, LCD_DC_IDX, 0, 0);
+    LGFX_GPIO_MATRIX_OUT(_cfg.pin_rs, LCD_DC_IDX);
   }
 
   void Bus_Parallel8::_read_bytes(uint8_t* dst, uint32_t length)


### PR DESCRIPTION
This pull request introduces multiple compatibility and bugfix improvements for ESP32 platforms, especially targeting ESP-IDF v6, ESP32P4, and Arduino Core v6. The changes address GPIO and DMA handling, UTF-8 decoding, font rendering, and build configuration to ensure better support for new SDK versions and hardware targets.

**Platform compatibility improvements:**

* Added conditional macros and includes in `Bus_Parallel8.cpp`, `Bus_SPI.cpp`, and related headers to handle ESP-IDF v6 changes, ESP32P4 target, and new/renamed SDK APIs for GPIO and DMA operations. This includes new wrapper macros for GPIO matrix functions and proper header selection for I2S and GDMA. [[1]](diffhunk://#diff-cfd9944c146d6132a92c4e20725255222074a6c0858eb8d90b6dac2258101401R29-R36) [[2]](diffhunk://#diff-adb110f9c9057f5ddfce35e1234ac27ea79e5e9aa5af985db59fec7a314c4af5R21-R25) [[3]](diffhunk://#diff-adb110f9c9057f5ddfce35e1234ac27ea79e5e9aa5af985db59fec7a314c4af5R71-R83) [[4]](diffhunk://#diff-ba75c7da91e306eb708985e8badbe6acec6eced214c3c9e8c6c35126e16c8857L30-R32)
* Updated `Light_PWM.cpp` to recognize and adapt to ESP32 Arduino Core v6, including disabling deprecated fields and updating feature macros. [[1]](diffhunk://#diff-47dae4a478634f2e9b0423ae009d4ea9f610b621426a4def02d7908eee124237R51-R53) [[2]](diffhunk://#diff-47dae4a478634f2e9b0423ae009d4ea9f610b621426a4def02d7908eee124237R75-R77)

**Bug fixes and code correctness:**

* Fixed signed/unsigned comparison warnings by casting loop variables in `LGFXBase.cpp`. [[1]](diffhunk://#diff-d0f233193c486fea65bd507a2c234b1354443b252277b7fd2ae81f307cb3a732L1096-R1098) [[2]](diffhunk://#diff-d0f233193c486fea65bd507a2c234b1354443b252277b7fd2ae81f307cb3a732L1121-R1125)
* Corrected type casting in `Bus_EPD.cpp` for ESP-IDF compatibility.
* Added missing `#include <driver/gpio.h>` for non-Arduino builds in `Light_PWM.cpp`.

**Font rendering and UTF-8 handling:**

* Improved UTF-8 decoding logic in `LGFXBase.cpp` to support up to 4-byte sequences and fixed the state machine for multibyte characters. Added a new decode state for 4-byte UTF-8. [[1]](diffhunk://#diff-d0f233193c486fea65bd507a2c234b1354443b252277b7fd2ae81f307cb3a732L2062-R2103) [[2]](diffhunk://#diff-ca737e6d1c13f2476fb218e0cb11e78d34ca12862ffbb54132163e3eb49c0c20R1025)
* Removed unnecessary `#ifdef` checks for LVGL font glyph formats, as these are enum values, not macros, in `lgfx_fonts.cpp`.
* Added an `#undef abs` guard to avoid macro conflicts in `lgfx_fonts.cpp`.

**Build system and configuration:**

* Fixed a file glob pattern in `CMakeLists.txt` to include all LVGL font `.c` files.

**ESP32-specific enhancements:**

* Updated SPI DMA and peripheral reset handling for ESP32P4 and other variants, including cache synchronization and register selection. [[1]](diffhunk://#diff-adb110f9c9057f5ddfce35e1234ac27ea79e5e9aa5af985db59fec7a314c4af5R213-R215) [[2]](diffhunk://#diff-adb110f9c9057f5ddfce35e1234ac27ea79e5e9aa5af985db59fec7a314c4af5R703-R724) [[3]](diffhunk://#diff-adb110f9c9057f5ddfce35e1234ac27ea79e5e9aa5af985db59fec7a314c4af5R933-R938) [[4]](diffhunk://#diff-adb110f9c9057f5ddfce35e1234ac27ea79e5e9aa5af985db59fec7a314c4af5R1222-R1233) [[5]](diffhunk://#diff-107d9b24361da9bcbe47979df8ba49addd46cfaf465cfd0cca496f7377df0445R93-R99) [[6]](diffhunk://#diff-107d9b24361da9bcbe47979df8ba49addd46cfaf465cfd0cca496f7377df0445R195-R197)
* Improved I2C clock source selection for ESP-IDF v6 in `common.cpp`.