### PR TITLE
ci: add workflow to publish to ESP Component Registry

### DIFF
--- a/.github/workflows/PushESPComponent.yml
+++ b/.github/workflows/PushESPComponent.yml
@@ -1,0 +1,22 @@
+name: Push component to ESP Component Registry
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  upload_components:
+    if: github.repository == 'm5stack/M5GFX'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Upload component to the component registry
+        uses: espressif/upload-components-ci-action@v1
+        with:
+          name: 'm5gfx'
+          namespace: 'm5stack'
+          version: ${{ github.ref_name }}
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/PushESPComponent.yml` to publish the component to the ESP Component Registry (`m5stack/m5gfx`) using `espressif/upload-components-ci-action@v1` whenever a SemVer-style tag (e.g. `0.2.22`) is pushed.
- Guarded with `if: github.repository == 'm5stack/M5GFX'` so the workflow is a no-op on forks.
- Migrates the publish flow that currently runs from a fork (`Forairaaaaa/M5GFX` `esp-component-register` branch) into the official repository.

## Notes
- Requires the `IDF_COMPONENT_API_TOKEN` secret (a token with publish permission for the `m5stack` namespace) to be registered in this repository's Actions secrets. Already configured.
- Once this PR is merged into master and the next release tag is pushed, the workflow will run automatically. The fork-side workflow can then be disabled to avoid duplicate uploads.

## Test plan
- [ ] After merge, push a tag like `0.2.22` and verify the workflow run succeeds
- [ ] Verify the new version appears on https://components.espressif.com/components/m5stack/m5gfx
- [ ] Confirm the workflow does not run on forks (job should be skipped)