### PR TITLE
Fix panel transaction shutdown order

### DIFF
--- a/src/lgfx/v1/panel/Panel_HasBuffer.cpp
+++ b/src/lgfx/v1/panel/Panel_HasBuffer.cpp
@@ -67,8 +67,9 @@ namespace lgfx
   {
     if (!_in_transaction) return;
     _in_transaction = false;
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
   }
 
   void Panel_HasBuffer::setRotation(uint_fast8_t r)

--- a/src/lgfx/v1/panel/Panel_IT8951.cpp
+++ b/src/lgfx/v1/panel/Panel_IT8951.cpp
@@ -236,8 +236,9 @@ IT8951 Registers defines
   {
     if (!_in_transaction) return;
     _in_transaction = false;
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
   }
 
   bool Panel_IT8951::_wait_busy(uint32_t timeout)

--- a/src/lgfx/v1/panel/Panel_M5UnitLCD.cpp
+++ b/src/lgfx/v1/panel/Panel_M5UnitLCD.cpp
@@ -78,8 +78,9 @@ namespace lgfx
   {
     if (!_in_transaction) return;
     _in_transaction = false;
-    _bus->endTransaction();
+    _bus->wait();
     cs_control(true);
+    _bus->endTransaction();
     _last_cmd = 0;
   }
 
@@ -96,8 +97,9 @@ namespace lgfx
         --_buff_free_count;
         return true;
       }
-      _bus->endTransaction();
+      _bus->wait();
       cs_control(true);
+      _bus->endTransaction();
       _bus->beginTransaction();
       cs_control(false);
       break;


### PR DESCRIPTION
## Summary
- Wait for pending bus transfers before releasing CS in panel transaction shutdown paths.
- Keep the bus endTransaction call after CS has been deasserted.
- Apply the ordering to Panel_HasBuffer, Panel_IT8951, and Panel_M5UnitLCD.