### PR TITLE
Harden DMA buffer allocation against transient heap exhaustion

### DIFF
--- a/src/lgfx/v1/Bus.hpp
+++ b/src/lgfx/v1/Bus.hpp
@@ -88,7 +88,12 @@ namespace lgfx
 
     /// DMA用のバッファを取得する。バスの実装によっては内部的には2個のバッファを交互に使用する。;
     /// 繰返し実行した場合は前回と異なるポインタを得るが、前々回と同じになる場合がある点に注意すること。;
+    /// メモリ枯渇時は nullptr を返しうるため、呼び出し側は必ず結果を確認すること。;
     virtual uint8_t* getDMABuffer(uint32_t length) = 0;
+
+    /// DMA用のバッファを事前確保する。以降、この長さまでの getDMABuffer は再確保なしで成功する。;
+    /// 内部バッファを持たないバス実装では何もしない。;
+    virtual bool reserveDMABuffer(uint32_t) { return true; }
 
     /// 未送信のデータがあれば送信を開始する。;
     virtual void flush(void) = 0;

--- a/src/lgfx/v1/panel/Panel_AMOLED.cpp
+++ b/src/lgfx/v1/panel/Panel_AMOLED.cpp
@@ -132,6 +132,35 @@ namespace lgfx
 */
         }
 
+        // getDMABuffer() returns nullptr when the DMA-capable internal heap
+        // cannot satisfy the request (transient starvation under memory
+        // pressure). Dropping the write is preferable to copying into a null
+        // pointer (StoreProhibited). Log only the OOM edge and the recovery
+        // edge, not every call.
+        uint8_t* Panel_AMOLED::get_dma_buffer_checked(size_t len)
+        {
+            auto buf = _bus->getDMABuffer(len);
+            if (!buf)
+            {
+              if (!_dma_oom)
+              {
+                _dma_oom = true;
+#if defined ( ESP_LOGW )
+                ESP_LOGW("Panel_AMOLED", "DMA buffer alloc failed (%u bytes); dropping pixels", (unsigned)len);
+#endif
+              }
+              return nullptr;
+            }
+            if (_dma_oom)
+            {
+              _dma_oom = false;
+#if defined ( ESP_LOGI )
+              ESP_LOGI("Panel_AMOLED", "DMA buffer available; resuming writes");
+#endif
+            }
+            return buf;
+        }
+
         void Panel_AMOLED::write_bytes(const uint8_t* data, uint32_t len, bool use_dma)
         {
             start_qspi();
@@ -577,7 +606,8 @@ namespace lgfx
                     else
                     {
                         size_t wb = w * bytes;
-                        auto buf = _bus->getDMABuffer(wb);
+                        auto buf = get_dma_buffer_checked(wb);
+                        if (!buf) { return; }
                         param->fp_copy(buf, 0, w, param);
                         setWindow(x, y, x + w - 1, y + h - 1);
                         write_bytes(buf, wb, true);
@@ -586,7 +616,8 @@ namespace lgfx
                         {
                             param->src_x = src_x;
                             param->src_y++;
-                            buf = _bus->getDMABuffer(wb);
+                            buf = get_dma_buffer_checked(wb);
+                            if (!buf) { return; }
                             param->fp_copy(buf, 0, w, param);
                             write_bytes(buf, wb, true);
                         }
@@ -602,7 +633,8 @@ namespace lgfx
                     uint32_t i = 0;
                     while (w != (i = param->fp_skip(i, w, param)))
                     {
-                        auto buf = _bus->getDMABuffer(wb);
+                        auto buf = get_dma_buffer_checked(wb);
+                        if (!buf) { return; }
                         int32_t len = param->fp_copy(buf, 0, w - i, param);
                         setWindow(x + i, y, x + i + len - 1, y);
                         write_bytes(buf, len * bytes, true);

--- a/src/lgfx/v1/panel/Panel_AMOLED.cpp
+++ b/src/lgfx/v1/panel/Panel_AMOLED.cpp
@@ -132,35 +132,6 @@ namespace lgfx
 */
         }
 
-        // getDMABuffer() returns nullptr when the DMA-capable internal heap
-        // cannot satisfy the request (transient starvation under memory
-        // pressure). Dropping the write is preferable to copying into a null
-        // pointer (StoreProhibited). Log only the OOM edge and the recovery
-        // edge, not every call.
-        uint8_t* Panel_AMOLED::get_dma_buffer_checked(size_t len)
-        {
-            auto buf = _bus->getDMABuffer(len);
-            if (!buf)
-            {
-              if (!_dma_oom)
-              {
-                _dma_oom = true;
-#if defined ( ESP_LOGW )
-                ESP_LOGW("Panel_AMOLED", "DMA buffer alloc failed (%u bytes); dropping pixels", (unsigned)len);
-#endif
-              }
-              return nullptr;
-            }
-            if (_dma_oom)
-            {
-              _dma_oom = false;
-#if defined ( ESP_LOGI )
-              ESP_LOGI("Panel_AMOLED", "DMA buffer available; resuming writes");
-#endif
-            }
-            return buf;
-        }
-
         void Panel_AMOLED::write_bytes(const uint8_t* data, uint32_t len, bool use_dma)
         {
             start_qspi();

--- a/src/lgfx/v1/panel/Panel_AMOLED.hpp
+++ b/src/lgfx/v1/panel/Panel_AMOLED.hpp
@@ -66,8 +66,11 @@ namespace lgfx
         {
         protected:
             bool _in_transaction = false;
+            bool _dma_oom = false;  // edge state: DMA buffer alloc failing
 
             Panel_AMOLED_Framebuffer* _panel_fb = nullptr;
+
+            uint8_t* get_dma_buffer_checked(size_t len);
 
             uint16_t _colstart = 0;
             uint16_t _rowstart = 0;

--- a/src/lgfx/v1/panel/Panel_AMOLED.hpp
+++ b/src/lgfx/v1/panel/Panel_AMOLED.hpp
@@ -55,7 +55,6 @@ namespace lgfx
         protected:
             uint8_t* _frame_buffer = nullptr;
             Panel_AMOLED* _panel = nullptr;
-            bool _dma_oom = false;  // edge state: DMA line-buffer alloc failing
         };
 
 
@@ -66,11 +65,8 @@ namespace lgfx
         {
         protected:
             bool _in_transaction = false;
-            bool _dma_oom = false;  // edge state: DMA buffer alloc failing
 
             Panel_AMOLED_Framebuffer* _panel_fb = nullptr;
-
-            uint8_t* get_dma_buffer_checked(size_t len);
 
             uint16_t _colstart = 0;
             uint16_t _rowstart = 0;

--- a/src/lgfx/v1/panel/Panel_Device.cpp
+++ b/src/lgfx/v1/panel/Panel_Device.cpp
@@ -22,6 +22,10 @@ Contributors:
 #include "../platforms/common.hpp"
 #include "../misc/pixelcopy.hpp"
 
+#if __has_include(<esp_log.h>)
+#include <esp_log.h>
+#endif
+
 namespace lgfx
 {
  inline namespace v1
@@ -68,12 +72,45 @@ namespace lgfx
       delay(8);
     }
     _bus->init();
+    // Pre-size the bus DMA buffers to one line of pixels (covering both
+    // rotations) so steady-state draws never reallocate mid-draw.
+    // Failure is tolerated: draw paths check getDMABuffer() results.
+    uint32_t line_max = _cfg.panel_width > _cfg.panel_height ? _cfg.panel_width : _cfg.panel_height;
+    _bus->reserveDMABuffer(line_max * ((_write_bits + 7) >> 3));
     rst_control(true);
     if (use_reset)
     {
       delay(64);
     }
     return true;
+  }
+
+  // getDMABuffer() returns nullptr when the DMA-capable heap cannot satisfy
+  // the request (transient starvation under memory pressure). Dropping the
+  // write is preferable to copying into a null pointer (StoreProhibited).
+  // Log only the OOM edge and the recovery edge, not every call.
+  uint8_t* Panel_Device::get_dma_buffer_checked(size_t len)
+  {
+    auto buf = _bus->getDMABuffer(len);
+    if (!buf)
+    {
+      if (!_dma_oom)
+      {
+        _dma_oom = true;
+#if defined ( ESP_LOGW )
+        ESP_LOGW("Panel_Device", "DMA buffer alloc failed (%u bytes); dropping pixels", (unsigned)len);
+#endif
+      }
+      return nullptr;
+    }
+    if (_dma_oom)
+    {
+      _dma_oom = false;
+#if defined ( ESP_LOGI )
+      ESP_LOGI("Panel_Device", "DMA buffer available; resuming writes");
+#endif
+    }
+    return buf;
   }
 
   bool Panel_Device::initTouch(void)
@@ -187,7 +224,8 @@ namespace lgfx
     pixelcopy_t pc_write(nullptr, _write_depth, _write_depth);
     for (;;)
     {
-      uint8_t* dmabuf = _bus->getDMABuffer((w+1) * bytes);
+      uint8_t* dmabuf = get_dma_buffer_checked((w+1) * bytes);
+      if (!dmabuf) { return; }
       pc_write.src_data = dmabuf;
       readRect(x, y, w, 1, dmabuf, &pc_read);
       {

--- a/src/lgfx/v1/panel/Panel_Device.hpp
+++ b/src/lgfx/v1/panel/Panel_Device.hpp
@@ -164,9 +164,14 @@ namespace lgfx
     ILight* _light = nullptr;
     ITouch* _touch = nullptr;
     bool _has_align_data = false;
+    bool _dma_oom = false;  // edge state: DMA buffer alloc failing
     uint8_t _internal_rotation = 0;
 
     float _affine[6] = {1,0,0,0,1,0};  /// touch affine parameter
+
+    /// _bus->getDMABuffer + エッジトリガーのログ。メモリ枯渇時は nullptr を返すため、;
+    /// 呼び出し側は必ず結果を確認し、失敗時は書き込みをスキップすること。;
+    uint8_t* get_dma_buffer_checked(size_t len);
 
     /// CSピンの準備処理を行う。CSピンを自前で制御する場合、この関数をoverrideして実装すること。;
     /// Performs preparation processing for the CS pin.

--- a/src/lgfx/v1/panel/Panel_ED2208.cpp
+++ b/src/lgfx/v1/panel/Panel_ED2208.cpp
@@ -445,7 +445,8 @@ namespace lgfx
     _send_command(0x10);    // Data start transmission
 
     for (uint_fast16_t y = 0; y < h; ++y) {
-      uint8_t* dst = _bus->getDMABuffer(row_bytes);
+      uint8_t* dst = get_dma_buffer_checked(row_bytes);
+      if (!dst) { break; }  // fall through to CS release / endTransaction
       const bgr888_t* src = reinterpret_cast<const bgr888_t*>(_lines_buffer[y]);
       dither_fn(src, dst, w, y, dither);
       _bus->writeBytes(dst, row_bytes, true, true);

--- a/src/lgfx/v1/panel/Panel_LCD.cpp
+++ b/src/lgfx/v1/panel/Panel_LCD.cpp
@@ -360,7 +360,8 @@ namespace lgfx
         else
         {
           size_t wb = w * bytes;
-          auto buf = _bus->getDMABuffer(wb);
+          auto buf = get_dma_buffer_checked(wb);
+          if (!buf) { return; }
           param->fp_copy(buf, 0, w, param);
           setWindow(x, y, x + w - 1, y + h - 1);
           write_bytes(buf, wb, true);
@@ -369,7 +370,8 @@ namespace lgfx
           {
             param->src_x = src_x;
             param->src_y++;
-            buf = _bus->getDMABuffer(wb);
+            buf = get_dma_buffer_checked(wb);
+            if (!buf) { return; }
             param->fp_copy(buf, 0, w, param);
             write_bytes(buf, wb, true);
           }
@@ -385,7 +387,8 @@ namespace lgfx
         uint32_t i = 0;
         while (w != (i = param->fp_skip(i, w, param)))
         {
-          auto buf = _bus->getDMABuffer(wb);
+          auto buf = get_dma_buffer_checked(wb);
+          if (!buf) { return; }
           int32_t len = param->fp_copy(buf, 0, w - i, param);
           setWindow(x + i, y, x + i + len - 1, y);
           write_bytes(buf, len * bytes, true);

--- a/src/lgfx/v1/panel/Panel_M5HDMI.cpp
+++ b/src/lgfx/v1/panel/Panel_M5HDMI.cpp
@@ -1315,7 +1315,8 @@ namespace lgfx
         uint32_t i = 0;
         while (w != (i = param->fp_skip(i, w, param)))
         {
-          auto dmabuf = _bus->getDMABuffer(wb + 1);
+          auto dmabuf = get_dma_buffer_checked(wb + 1);
+          if (!dmabuf) { return; }
           int32_t len = param->fp_copy(dmabuf, 0, w - i, param);
           _set_window(x + i, y, x + i + len - 1, y, cmd);
           _bus->writeBytes(dmabuf, len * bytes, false, true);

--- a/src/lgfx/v1/panel/Panel_M5UnitLCD.cpp
+++ b/src/lgfx/v1/panel/Panel_M5UnitLCD.cpp
@@ -477,7 +477,8 @@ if (bytelen != rleDecode(dest, res, bytes)*bytes) {
     (void)use_dma;
     auto bytes = _write_bits >> 3;
     uint32_t wb = length * bytes;
-    auto dmabuf = _bus->getDMABuffer(wb + (wb >> 7) + 128);
+    auto dmabuf = get_dma_buffer_checked(wb + (wb >> 7) + 128);
+    if (!dmabuf) { return; }
     dmabuf[0] = CMD_WRITE_RLE | bytes;
     size_t idx = _check_repeat(dmabuf[0]) ? 0 : 1;
 
@@ -553,11 +554,12 @@ if (bytelen != rleDecode(dest, res, bytes)*bytes) {
       uint32_t i = 0;
       while (w != (i = param->fp_skip(i, w, param)))
       {
+        auto dmabuf = get_dma_buffer_checked(wb + (wb >> 7) + 128);
+        if (!dmabuf) { return; }
         auto sub = (w - i) >> 2;
         _buff_free_count = (_buff_free_count > sub)
                          ? (_buff_free_count - sub)
                          : 0;
-        auto dmabuf = _bus->getDMABuffer(wb + (wb >> 7) + 128);
         dmabuf[0] = cmd;
         auto buf = &dmabuf[(wb >> 7) + 128];
         int32_t len = param->fp_copy(buf, 0, w - i, param);

--- a/src/lgfx/v1/platforms/common.hpp
+++ b/src/lgfx/v1/platforms/common.hpp
@@ -94,15 +94,45 @@ namespace lgfx
       }
     }
 
+    // Pre-allocate the buffer and set a floor below which getBuffer()
+    // never shrinks it. See FlipBuffer::reserve.
+    bool reserve(size_t length)
+    {
+      length = (length + 3) & ~3;
+      if (_reserved < length) { _reserved = length; }
+      if (_length >= length) { return true; }
+      if (_buffer) { heap_free(_buffer); }
+      _buffer = (uint8_t*)heap_alloc_dma(length);
+      _length = _buffer ? length : 0;
+      return _buffer != nullptr;
+    }
+
     uint8_t* getBuffer(size_t length)
     {
       length = (length + 3) & ~3;
 
-      if (_length != length)
-      {
+      if (_length < length)
+      { // Grow: the current buffer cannot serve this request anyway, so
+        // free it first to give the allocator its best chance.
         if (_buffer) heap_free(_buffer);
         _buffer = (uint8_t*)heap_alloc_dma(length);
         _length = _buffer ? length : 0;
+      }
+      else
+      { // Shrink: reclaim memory, but never below the reserved floor, and
+        // never by discarding a buffer that already satisfies the request;
+        // allocate the smaller one first and keep the old one on failure.
+        size_t keep = (length > _reserved) ? length : _reserved;
+        if (_length > keep + 64)
+        {
+          auto newbuf = (uint8_t*)heap_alloc_dma(keep);
+          if (newbuf)
+          {
+            heap_free(_buffer);
+            _buffer = newbuf;
+            _length = keep;
+          }
+        }
       }
       return _buffer;
     }
@@ -110,6 +140,7 @@ namespace lgfx
   private:
     uint8_t* _buffer = nullptr;
     size_t _length = 0;
+    size_t _reserved = 0;
   };
 
 //----------------------------------------------------------------------------
@@ -135,16 +166,53 @@ namespace lgfx
       }
     }
 
+    // Pre-allocate both buffers and set a floor below which getBuffer()
+    // never shrinks them. Called at init time (e.g. with one line of
+    // pixels), this makes steady-state getBuffer() calls allocation-free,
+    // so transient heap starvation cannot fail them mid-draw.
+    bool reserve(size_t length)
+    {
+      length = (length + 3) & ~3;
+      if (_reserved < length) { _reserved = length; }
+      bool result = true;
+      for (size_t i = 0; i < 2; i++)
+      {
+        if (_length[i] >= length) { continue; }
+        if (_buffer[i]) { heap_free(_buffer[i]); }
+        _buffer[i] = (uint8_t*)heap_alloc_dma(length);
+        _length[i] = _buffer[i] ? length : 0;
+        result = result && (_buffer[i] != nullptr);
+      }
+      return result;
+    }
+
     uint8_t* getBuffer(size_t length)
     {
       length = (length + 3) & ~3;
       _flip = !_flip;
 
-      if (_length[_flip] < length || _length[_flip] > length + 64)
-      {
+      if (_length[_flip] < length)
+      { // Grow: the current buffer cannot serve this request anyway, so
+        // free it first to give the allocator its best chance.
         if (_buffer[_flip]) { heap_free(_buffer[_flip]); }
         _buffer[_flip] = (uint8_t*)heap_alloc_dma(length);
         _length[_flip] = _buffer[_flip] ? length : 0;
+      }
+      else
+      { // Shrink: reclaim memory, but never below the reserved floor, and
+        // never by discarding a buffer that already satisfies the request;
+        // allocate the smaller one first and keep the old one on failure.
+        size_t keep = (length > _reserved) ? length : _reserved;
+        if (_length[_flip] > keep + 64)
+        {
+          auto newbuf = (uint8_t*)heap_alloc_dma(keep);
+          if (newbuf)
+          {
+            heap_free(_buffer[_flip]);
+            _buffer[_flip] = newbuf;
+            _length[_flip] = keep;
+          }
+        }
       }
       return _buffer[_flip];
     }
@@ -152,6 +220,7 @@ namespace lgfx
   private:
     uint8_t* _buffer[2] = { nullptr, nullptr };
     size_t _length[2] = { 0, 0 };
+    size_t _reserved = 0;
     bool _flip = false;
   };
 

--- a/src/lgfx/v1/platforms/esp32/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_I2C.hpp
@@ -67,6 +67,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) {}
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;

--- a/src/lgfx/v1/platforms/esp32/Bus_Parallel8.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_Parallel8.hpp
@@ -107,6 +107,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) override { flush(); };
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;

--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.hpp
@@ -133,6 +133,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override;
     void execDMAQueue(void) override;
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(uint_fast8_t dummy_bits) override;
     void beginRead(void) override;

--- a/src/lgfx/v1/platforms/esp32c3/Bus_Parallel8.hpp
+++ b/src/lgfx/v1/platforms/esp32c3/Bus_Parallel8.hpp
@@ -77,6 +77,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) override {};
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.hpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel16.hpp
@@ -120,6 +120,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) override { flush(); };
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;

--- a/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.hpp
+++ b/src/lgfx/v1/platforms/esp32s2/Bus_Parallel8.hpp
@@ -112,6 +112,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) override { flush(); };
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;

--- a/src/lgfx/v1/platforms/esp32s3/Bus_Parallel16.hpp
+++ b/src/lgfx/v1/platforms/esp32s3/Bus_Parallel16.hpp
@@ -104,6 +104,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) override { flush(); };
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;

--- a/src/lgfx/v1/platforms/esp32s3/Bus_Parallel8.hpp
+++ b/src/lgfx/v1/platforms/esp32s3/Bus_Parallel8.hpp
@@ -96,6 +96,7 @@ namespace lgfx
     void addDMAQueue(const uint8_t* data, uint32_t length) override { writeBytes(data, length, true, true); }
     void execDMAQueue(void) override { flush(); };
     uint8_t* getDMABuffer(uint32_t length) override { return _flip_buffer.getBuffer(length); }
+    bool reserveDMABuffer(uint32_t length) override { return _flip_buffer.reserve(length); }
 
     void beginRead(void) override;
     void endRead(void) override;


### PR DESCRIPTION
Follow-up to #211, extending the null-DMA-buffer protection from the AMOLED framebuffer flush to the whole library.

## Problem

`IBus::getDMABuffer()` returns `nullptr` when the DMA-capable internal heap is transiently exhausted. #211 guarded one call site, but the same unchecked pattern existed across the panel layer (`Panel_LCD`, `Panel_M5HDMI`, `Panel_ED2208`, `Panel_M5UnitLCD`, `Panel_Device::writeImageARGB`), and the underlying buffer classes had a self-inflicted failure mode: on a size change they freed the old buffer *before* allocating the new one, so a buffer that could still satisfy the request was lost when the allocation failed. `SimpleBuffer` (used by `Bus_I2C`) reallocated on *any* size change, not just growth.

## Changes

**Buffer layer** (`platforms/common.hpp`)
- `FlipBuffer` / `SimpleBuffer`: shrinking now allocates the smaller buffer first and keeps the old one on failure; a buffer that already satisfies the request is never discarded.
- New `reserve()`: pre-allocates and sets a floor below which `getBuffer()` never shrinks.

**Bus layer**
- `IBus::reserveDMABuffer()` (default no-op), implemented by the esp32-family buses.

**Panel layer**
- `Panel_Device::init()` reserves one line of pixels (covering both rotations), so steady-state draws never reallocate mid-draw.
- New protected `Panel_Device::get_dma_buffer_checked()` with edge-triggered `ESP_LOGW`/`ESP_LOGI` (no per-frame spam); all live `getDMABuffer()` call sites in the panel layer now use it and skip the write on failure (`Panel_ED2208` breaks to its transaction/CS cleanup instead of returning). `Panel_AMOLED` migrates its #211-era local helper to the shared one.

## Behavior on exhaustion

Instead of a `StoreProhibited` panic, the affected write is dropped (pixels skipped; the AMOLED framebuffer path retries via its dirty rectangle) and a single warning is logged until recovery.

## Notes

- The init-time reservation makes the previously lazy per-line DMA allocation eager and permanent (e.g. ~5 KB internal RAM for a 1280-wide 16bpp panel). This is intentional: the same memory was allocated on the first full-width draw anyway; now it cannot be lost to transient pressure.
- Verified with esp32 / esp32s3 builds; an independent adversarial review of the diff found no correctness regressions.
- Same change ported to LovyanGFX develop.