### PR TITLE
Pin all board_t enumerators to explicit values

### DIFF
--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -4,90 +4,92 @@
 namespace lgfx // This should not be changed to "m5gfx"
 {
   namespace boards
-  { // Be careful not to change existing board numbers when adding values.
+  { // Board IDs are canonically assigned in the m5stack-board-id repository.
+    // https://github.com/m5stack/m5stack-board-id/blob/main/board.csv
+    // When adding a new board, obtain its BID there first; never renumber existing entries.
     enum board_t
     { board_unknown = 0
-    , board_M5Stack
-    , board_M5StackCore2
-    , board_M5StickC
-    , board_M5StickCPlus
-    , board_M5StickCPlus2
-    , board_M5StackCoreInk
-    , board_M5Paper
-    , board_M5Tough
-    , board_M5Station
-    , board_M5StackCoreS3
-    , board_M5AtomS3
-    , board_M5Dial
-    , board_M5DinMeter
-    , board_M5Cardputer
-    , board_M5AirQ
-    , board_M5VAMeter
-    , board_M5StackCoreS3SE
-    , board_M5AtomS3R
-    , board_M5PaperS3
-    , board_M5CoreMP135
-    , board_M5StampPLC
-    , board_M5Tab5
-    , board_ArduinoNessoN1
-    , board_M5CardputerADV
-    , board_M5UnitC6L
-    , board_M5StickS3
-    , board_M5StackChan
-    , board_M5PaperColor
-    , board_M5PaperMono
-    , board_M5StopWatch
-    , board_M5CoreP4X
-    , board_M5ChainCaptain
-    , board_M5ToughC5
+    , board_M5Stack = 1
+    , board_M5StackCore2 = 2
+    , board_M5StickC = 3
+    , board_M5StickCPlus = 4
+    , board_M5StickCPlus2 = 5
+    , board_M5StackCoreInk = 6
+    , board_M5Paper = 7
+    , board_M5Tough = 8
+    , board_M5Station = 9
+    , board_M5StackCoreS3 = 10
+    , board_M5AtomS3 = 11
+    , board_M5Dial = 12
+    , board_M5DinMeter = 13
+    , board_M5Cardputer = 14
+    , board_M5AirQ = 15
+    , board_M5VAMeter = 16
+    , board_M5StackCoreS3SE = 17
+    , board_M5AtomS3R = 18
+    , board_M5PaperS3 = 19
+    , board_M5CoreMP135 = 20
+    , board_M5StampPLC = 21
+    , board_M5Tab5 = 22
+    , board_ArduinoNessoN1 = 23
+    , board_M5CardputerADV = 24
+    , board_M5UnitC6L = 25
+    , board_M5StickS3 = 26
+    , board_M5StackChan = 27
+    , board_M5PaperColor = 28
+    , board_M5PaperMono = 29
+    , board_M5StopWatch = 30
+    , board_M5CoreP4X = 31
+    , board_M5ChainCaptain = 32
+    , board_M5ToughC5 = 33
 
 /// non display boards
     , board_M5AtomLite = 128
     , board_M5ATOM __attribute__ ((deprecated)) = board_M5AtomLite
     , board_M5Atom __attribute__ ((deprecated)) = board_M5AtomLite
-    , board_M5AtomPsram
-    , board_M5AtomU
-    , board_M5Camera
-    , board_M5TimerCam
-    , board_M5StampPico
-    , board_M5StampC3
-    , board_M5StampC3U
-    , board_M5StampS3
-    , board_M5AtomS3Lite
-    , board_M5AtomS3U
-    , board_M5Capsule
-    , board_M5NanoC6
-    , board_M5AtomMatrix
-    , board_M5AtomVoice
+    , board_M5AtomPsram = 129
+    , board_M5AtomU = 130
+    , board_M5Camera = 131
+    , board_M5TimerCam = 132
+    , board_M5StampPico = 133
+    , board_M5StampC3 = 134
+    , board_M5StampC3U = 135
+    , board_M5StampS3 = 136
+    , board_M5AtomS3Lite = 137
+    , board_M5AtomS3U = 138
+    , board_M5Capsule = 139
+    , board_M5NanoC6 = 140
+    , board_M5AtomMatrix = 141
+    , board_M5AtomVoice = 142
     , board_M5AtomEcho __attribute__ ((deprecated)) = board_M5AtomVoice
-    , board_M5AtomS3RExt
-    , board_M5AtomS3RCam
-    , board_M5AtomVoiceS3R
+    , board_M5AtomS3RExt = 143
+    , board_M5AtomS3RCam = 144
+    , board_M5AtomVoiceS3R = 145
     , board_M5AtomEchoS3R __attribute__ ((deprecated)) = board_M5AtomVoiceS3R
-    , board_M5PowerHub
-    , board_M5DualKey
-    , board_M5UnitPoEP4
-    , board_M5StampS3Bat
-    , board_M5StampP4
-    , board_M5NanoH2
-    , board_M5CoreMatrix
-    , board_M5StampC5
-    , board_M5StampC6
-    , board_M5StampS3Mini
-    , board_M5StampP4X
+    , board_M5PowerHub = 146
+    , board_M5DualKey = 147
+    , board_M5UnitPoEP4 = 148
+    , board_M5StampS3Bat = 149
+    , board_M5StampP4 = 150
+    , board_M5NanoH2 = 151
+    , board_M5CoreMatrix = 152
+    , board_M5StampC5 = 153
+    , board_M5StampC6 = 154
+    , board_M5StampS3Mini = 155
+    , board_M5StampP4X = 156
 
 /// external displays
     , board_M5AtomDisplay = 192
     , board_M5ATOMDisplay = board_M5AtomDisplay
-    , board_M5UnitLCD
-    , board_M5UnitOLED
-    , board_M5UnitMiniOLED
-    , board_M5UnitGLASS
-    , board_M5UnitGLASS2
-    , board_M5UnitRCA
-    , board_M5ModuleDisplay
-    , board_M5ModuleRCA
-    , board_M5UnitPoEP4HDMI
+    , board_M5UnitLCD = 193
+    , board_M5UnitOLED = 194
+    , board_M5UnitMiniOLED = 195
+    , board_M5UnitGLASS = 196
+    , board_M5UnitGLASS2 = 197
+    , board_M5UnitRCA = 198
+    , board_M5ModuleDisplay = 199
+    , board_M5ModuleRCA = 200
+    , board_M5UnitPoEP4HDMI = 201
 
     , board_FrameBuffer = 512
     };


### PR DESCRIPTION

## Summary

Assigns every `board_t` enumerator in `src/lgfx/boards.hpp` its explicit numeric value, and adds a comment pointing to the canonical board-ID registry ([m5stack-board-id / board.csv](https://github.com/m5stack/m5stack-board-id/blob/main/board.csv)).

## Motivation

`board_t` values are persisted (NVS) and exchanged across firmware versions, so an accidental shift of implicit enum values would silently break board identification. With implicit values, inserting or removing a single entry renumbers every subsequent board — and a partial pinning would still leave the gaps between pinned entries vulnerable. Pinning **all** entries makes any accidental renumbering visible in the diff and lets each entry be checked against the registry at a glance.

## Verification (binary no-op)

- A host-compiled probe printing every enumerator (79 total) confirmed all values are **identical before and after** this change.
- The enum's value set was cross-checked against `board.csv`: all entries match. The only values not (yet) in the CSV are `board_M5UnitPoEP4HDMI = 201` (registration pending) and `board_FrameBuffer = 512` (pseudo-board, out of scope for the registry).
- The four intentional alias groups are kept in `= board_X` form: `ATOM/Atom→AtomLite` (128), `AtomEcho→AtomVoice` (142), `AtomEchoS3R→AtomVoiceS3R` (145), `ATOMDisplay→AtomDisplay` (192).

No behavior change; purely a hardening of the header against future editing mistakes.
