### PR TITLE
Low power I2C support and software (bit-banged) I2C / SPI on negative port numbers

### DIFF
--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -82,6 +82,13 @@ namespace m5gfx
     }
   }
 
+  // ボード未確定段階の I2C プローブに使うソフトウェア I2C ポート (GPIO ビットバン)。
+  // ハードウェアのペリフェラルを一切確保・設定しないため、候補ボードの試行が
+  // ペリフェラルやピンの状態を汚さない。ボード確定後の常用バスは従来どおり
+  // ハードウェアポートを使う。
+  __attribute__ ((unused))
+  static constexpr int_fast16_t probe_i2c_port = -1;
+
   // I2Cデバイスの存在をチェックする。
   // SDA,SCLのプルアップが確認できない場合は0を返す。
   // プルアップが確認できた場合は ~0u を返すが、存在しないデバイスに対応するビットは 0 となる。
@@ -134,31 +141,17 @@ namespace m5gfx
       // 全ビットを立てる
       result = ~0u;
 
-      // for (int addr7bit = 0x08; addr7bit < 0x78; ++addr7bit) {
+      // アドレスの存在確認はソフトウェア I2C ポートで行う (オープンドレイン駆動で
+      // ACK 競合が起きず、ハードウェアのペリフェラルにも触れない)
+      lgfx::i2c::init(probe_i2c_port, pin_sda, pin_scl);
       for (; addr_list[0] != 0; ++addr_list) {
-        // 7bit addr + write flag + ack check;
         uint_fast8_t addr7bit = addr_list[0];
-        // ACKチェック用ビットも含め左2bitシフトし、9bit相当にする
-        uint_fast16_t sda_bits = (addr7bit << 2u) + 1u;
-        lgfx::delayMicroseconds(5);
-        lgfx::gpio_lo(pin_sda);
-        lgfx::delayMicroseconds(5);
-        for (int i = 0; i < 9; ++i) {
-          lgfx::gpio_lo(pin_scl);
-          if (sda_bits & 0x100u) { lgfx::gpio_hi(pin_sda); }
-          else { lgfx::gpio_lo(pin_sda); }
-          sda_bits <<= 1;
-          lgfx::delayMicroseconds(3);
-          lgfx::gpio_hi(pin_scl);
-          lgfx::delayMicroseconds(6);
-        }
-        bool hit = !lgfx::gpio_in(pin_sda);
+        bool hit = lgfx::i2c::beginTransaction(probe_i2c_port, addr7bit, 100000, false).has_value()
+                && lgfx::i2c::endTransaction(probe_i2c_port).has_value();
         result = (result << 1) + hit;
         ESP_LOGV(LIBRARY_NAME, "[Autodetect] i2c addr:%02x = %s", (int)addr7bit, hit ? "hit" : "--");
-
-        // i2c stop
-        lgfx::gpio::command(cmd_i2c_stop_list);
       }
+      lgfx::i2c::release(probe_i2c_port);
     } else {
       result = 0;
     }
@@ -2763,10 +2756,11 @@ The usage of each pin is as follows.
         // TP INT = GPIO_NUM_23
         lgfx::pinMode(GPIO_NUM_23, lgfx::pin_mode_t::output); // TP INT
         lgfx::gpio_hi(GPIO_NUM_23); // select I2C Addr (high=0x14 / low=0x5D)
-        lgfx::i2c::init(in_i2c_port, GPIO_NUM_31, GPIO_NUM_32);
+        // ボード確定まではソフトウェア I2C で通信し、ハードウェアポートを温存する
+        lgfx::i2c::init(probe_i2c_port, GPIO_NUM_31, GPIO_NUM_32);
 
-        id = lgfx::i2c::readRegister8(in_i2c_port, pi4io1_i2c_addr, 0x01).has_value()
-          && lgfx::i2c::readRegister8(in_i2c_port, pi4io2_i2c_addr, 0x01).has_value();
+        id = lgfx::i2c::readRegister8(probe_i2c_port, pi4io1_i2c_addr, 0x01).has_value()
+          && lgfx::i2c::readRegister8(probe_i2c_port, pi4io2_i2c_addr, 0x01).has_value();
         if (id != 0) {
           board = board_t::board_M5Tab5;
           ESP_LOGI(LIBRARY_NAME, "[Autodetect] board_M5Tab5");
@@ -2795,10 +2789,10 @@ The usage of each pin is as follows.
             0xFF,0xFF,0xFF,
           };
 
-          i2c_write_register8_array(in_i2c_port, pi4io1_i2c_addr, reg_data_io1_1, 100000);
-          i2c_write_register8_array(in_i2c_port, pi4io2_i2c_addr, reg_data_io2, 100000);
+          i2c_write_register8_array(probe_i2c_port, pi4io1_i2c_addr, reg_data_io1_1, 100000);
+          i2c_write_register8_array(probe_i2c_port, pi4io2_i2c_addr, reg_data_io2, 100000);
           lgfx::delay(10);
-          i2c_write_register8_array(in_i2c_port, pi4io1_i2c_addr, reg_data_io1_2, 100000);
+          i2c_write_register8_array(probe_i2c_port, pi4io1_i2c_addr, reg_data_io1_2, 100000);
           lgfx::pinMode(GPIO_NUM_23, lgfx::pin_mode_t::input); // TP INT
           lgfx::delay(100);
 
@@ -2821,7 +2815,7 @@ The usage of each pin is as follows.
             for (int i = 0; i < 3; ++i) {
               uint8_t fw_version = 0;
               uint8_t fw_reg[2] = { 0, 0 };
-              if (lgfx::i2c::transactionWriteRead(in_i2c_port, Touch_ST7123::default_addr, fw_reg, sizeof(fw_reg), &fw_version, 1, 100000).has_value()) {
+              if (lgfx::i2c::transactionWriteRead(probe_i2c_port, Touch_ST7123::default_addr, fw_reg, sizeof(fw_reg), &fw_version, 1, 100000).has_value()) {
                 read_st_touch_fw = true;
                 ESP_LOGI(LIBRARY_NAME, "M5Tab5 ST touch FW version %02x", fw_version);
                 if (fw_version == 1) {
@@ -2839,6 +2833,11 @@ The usage of each pin is as follows.
             if (!read_st_touch_fw) {
               ESP_LOGW(LIBRARY_NAME, "M5Tab5 ST touch FW version read failed");
             }
+
+            // ボードが確定し I2C の用は済んだので、常用するハードウェアポートへ
+            // バスを引き継ぐ (タッチがこのポートを使う)
+            lgfx::i2c::release(probe_i2c_port);
+            lgfx::i2c::init(in_i2c_port, GPIO_NUM_31, GPIO_NUM_32);
 
             auto bus_dsi = new Bus_DSI();
             _bus_last.reset(bus_dsi);
@@ -2964,6 +2963,8 @@ The usage of each pin is as follows.
           }
           goto init_clear;
         }
+        // ボード不成立時のみここへ来る。プローブに使ったソフトウェアポートを返す
+        lgfx::i2c::release(probe_i2c_port);
       }
     }
 
@@ -3065,7 +3066,8 @@ The usage of each pin is as follows.
         } else
         if (result == 0x03)
         { // NessoN1 ?
-          lgfx::i2c::init(i2c_port, GPIO_NUM_10, GPIO_NUM_8);
+          // パネル ID で確定するまではソフトウェア I2C で通信する
+          lgfx::i2c::init(probe_i2c_port, GPIO_NUM_10, GPIO_NUM_8);
         // PI4IO E0
         //  P0 BTN1
         //  P1 BTN2
@@ -3101,8 +3103,8 @@ The usage of each pin is as follows.
             0x05, 0b10000010, 0,   // PI4IO_REG_OUT_SET
             0xFF,0xFF,0xFF,
           };
-          i2c_write_register8_array(i2c_port, pi4io2_i2c_addr, reg_data_io2, 100000);
-          i2c_write_register8_array(i2c_port, pi4io1_i2c_addr, reg_data_io1, 100000);
+          i2c_write_register8_array(probe_i2c_port, pi4io2_i2c_addr, reg_data_io2, 100000);
+          i2c_write_register8_array(probe_i2c_port, pi4io1_i2c_addr, reg_data_io1, 100000);
 
           bus_cfg.pin_mosi = GPIO_NUM_21;
           bus_cfg.pin_miso = GPIO_NUM_22;
@@ -3119,6 +3121,11 @@ The usage of each pin is as follows.
           {
             board = board_t::board_ArduinoNessoN1;
             ESP_LOGI(LIBRARY_NAME, "[Autodetect] board_ArduinoNessoN1");
+
+            // ボードが確定したので、常用するハードウェアポートへバスを引き継ぐ
+            // (バックライトとタッチがこのポートを使う)
+            lgfx::i2c::release(probe_i2c_port);
+            lgfx::i2c::init(i2c_port, GPIO_NUM_10, GPIO_NUM_8);
 
             bus_spi->release();
             bus_cfg.freq_write = 40000000;
@@ -3174,6 +3181,9 @@ The usage of each pin is as follows.
           }
           bus_spi->release();
         }
+        // ボード不成立時のみここへ来る (成立時は goto で抜けている)。
+        // プローブに使ったソフトウェアポートを返し、ピンを元へ戻す
+        lgfx::i2c::release(probe_i2c_port);
         for (auto &bup : backup_pins) { bup.restore(); }
       }
     }
@@ -3213,16 +3223,17 @@ The usage of each pin is as follows.
       , GPIO_NUM_26
       };
 
-      lgfx::i2c::init(i2c_port, toughc5_i2c_sda, toughc5_i2c_scl);
+      // ボード確定まではソフトウェア I2C で通信し、ハードウェアポートを温存する
+      lgfx::i2c::init(probe_i2c_port, toughc5_i2c_sda, toughc5_i2c_scl);
 
-      if (_check_m5pm1(i2c_port) && _check_m5ioe1(i2c_port)) {
+      if (_check_m5pm1(probe_i2c_port) && _check_m5ioe1(probe_i2c_port)) {
         // M5PM1 初期化
-        lgfx::i2c::writeRegister8(i2c_port, m5pm1_i2c_addr, 0x09, 0x00, 0, m5pm1_i2c_freq); // I2C sleep disable
-        lgfx::i2c::writeRegister8(i2c_port, m5pm1_i2c_addr, 0x0A, 0x00, 0, m5pm1_i2c_freq); // WDT disable
-        lgfx::i2c::bitOn( i2c_port, m5pm1_i2c_addr, 0x06, 0x17, m5pm1_i2c_freq); // PWR_CFG: LED_CTRL, LDO, DCDC, CHG enable
+        lgfx::i2c::writeRegister8(probe_i2c_port, m5pm1_i2c_addr, 0x09, 0x00, 0, m5pm1_i2c_freq); // I2C sleep disable
+        lgfx::i2c::writeRegister8(probe_i2c_port, m5pm1_i2c_addr, 0x0A, 0x00, 0, m5pm1_i2c_freq); // WDT disable
+        lgfx::i2c::bitOn( probe_i2c_port, m5pm1_i2c_addr, 0x06, 0x17, m5pm1_i2c_freq); // PWR_CFG: LED_CTRL, LDO, DCDC, CHG enable
 
         // M5IOE1 初期化
-        lgfx::i2c::writeRegister8(i2c_port, m5ioe1_i2c_addr, 0x23, 0x00, 0, m5ioe1_i2c_freq); // I2C sleep disable
+        lgfx::i2c::writeRegister8(probe_i2c_port, m5ioe1_i2c_addr, 0x23, 0x00, 0, m5ioe1_i2c_freq); // I2C sleep disable
 
         // M5IOE1 PIN4(LCD_RST), PIN5(LCD_EN), PIN10(LCD_BL) を出力に設定
         // PIN4=bit3, PIN5=bit4 → low register (0x03/0x05/0x13)
@@ -3230,30 +3241,30 @@ The usage of each pin is as follows.
         static constexpr uint8_t IOE1_PIN_10 = 9;
         static constexpr uint8_t IOE1_BIT_10_H = (1u << (IOE1_PIN_10 - 8));
 
-        lgfx::i2c::bitOff(i2c_port, m5ioe1_i2c_addr, 0x13, 0b00011000, m5ioe1_i2c_freq);  // PIN4,5 push-pull
-        lgfx::i2c::bitOff(i2c_port, m5ioe1_i2c_addr, 0x14, IOE1_BIT_10_H, m5ioe1_i2c_freq);  // PIN10 push-pull
-        lgfx::i2c::bitOn( i2c_port, m5ioe1_i2c_addr, 0x03, 0b00011000, m5ioe1_i2c_freq);  // PIN4,5 output
-        lgfx::i2c::bitOn( i2c_port, m5ioe1_i2c_addr, 0x04, IOE1_BIT_10_H, m5ioe1_i2c_freq);  // PIN10 output
+        lgfx::i2c::bitOff(probe_i2c_port, m5ioe1_i2c_addr, 0x13, 0b00011000, m5ioe1_i2c_freq);  // PIN4,5 push-pull
+        lgfx::i2c::bitOff(probe_i2c_port, m5ioe1_i2c_addr, 0x14, IOE1_BIT_10_H, m5ioe1_i2c_freq);  // PIN10 push-pull
+        lgfx::i2c::bitOn( probe_i2c_port, m5ioe1_i2c_addr, 0x03, 0b00011000, m5ioe1_i2c_freq);  // PIN4,5 output
+        lgfx::i2c::bitOn( probe_i2c_port, m5ioe1_i2c_addr, 0x04, IOE1_BIT_10_H, m5ioe1_i2c_freq);  // PIN10 output
 
         // LCD enable
-        lgfx::i2c::bitOn( i2c_port, m5ioe1_i2c_addr, 0x05, 1 << 4, m5ioe1_i2c_freq);  // PIN5(LCD_EN) HIGH
+        lgfx::i2c::bitOn( probe_i2c_port, m5ioe1_i2c_addr, 0x05, 1 << 4, m5ioe1_i2c_freq);  // PIN5(LCD_EN) HIGH
 
         // LCD reset
         if (use_reset) {
-          lgfx::i2c::bitOff(i2c_port, m5ioe1_i2c_addr, 0x05, 1 << 3, m5ioe1_i2c_freq);  // PIN4(LCD_RST) LOW
+          lgfx::i2c::bitOff(probe_i2c_port, m5ioe1_i2c_addr, 0x05, 1 << 3, m5ioe1_i2c_freq);  // PIN4(LCD_RST) LOW
           lgfx::delay(2);
-          lgfx::i2c::bitOn( i2c_port, m5ioe1_i2c_addr, 0x05, 1 << 3, m5ioe1_i2c_freq);  // PIN4(LCD_RST) HIGH
+          lgfx::i2c::bitOn( probe_i2c_port, m5ioe1_i2c_addr, 0x05, 1 << 3, m5ioe1_i2c_freq);  // PIN4(LCD_RST) HIGH
           lgfx::delay(10);
         }
 
         // M5PM1 GPIO2(TP_RST) を出力に設定してリセット
-        lgfx::i2c::bitOff(i2c_port, m5pm1_i2c_addr, 0x16, 0b11 << (2*2), m5pm1_i2c_freq); // GPIO2 → GPIO function
-        lgfx::i2c::bitOn( i2c_port, m5pm1_i2c_addr, 0x10, 1 << 2, m5pm1_i2c_freq);  // GPIO2 output
-        lgfx::i2c::bitOff(i2c_port, m5pm1_i2c_addr, 0x13, 1 << 2, m5pm1_i2c_freq);  // GPIO2 push-pull
+        lgfx::i2c::bitOff(probe_i2c_port, m5pm1_i2c_addr, 0x16, 0b11 << (2*2), m5pm1_i2c_freq); // GPIO2 → GPIO function
+        lgfx::i2c::bitOn( probe_i2c_port, m5pm1_i2c_addr, 0x10, 1 << 2, m5pm1_i2c_freq);  // GPIO2 output
+        lgfx::i2c::bitOff(probe_i2c_port, m5pm1_i2c_addr, 0x13, 1 << 2, m5pm1_i2c_freq);  // GPIO2 push-pull
         if (use_reset) {
-          lgfx::i2c::bitOff(i2c_port, m5pm1_i2c_addr, 0x11, 1 << 2, m5pm1_i2c_freq);  // GPIO2(TP_RST) LOW
+          lgfx::i2c::bitOff(probe_i2c_port, m5pm1_i2c_addr, 0x11, 1 << 2, m5pm1_i2c_freq);  // GPIO2(TP_RST) LOW
           lgfx::delay(2);
-          lgfx::i2c::bitOn( i2c_port, m5pm1_i2c_addr, 0x11, 1 << 2, m5pm1_i2c_freq);  // GPIO2(TP_RST) HIGH
+          lgfx::i2c::bitOn( probe_i2c_port, m5pm1_i2c_addr, 0x11, 1 << 2, m5pm1_i2c_freq);  // GPIO2(TP_RST) HIGH
           lgfx::delay(10);
         }
 
@@ -3272,6 +3283,11 @@ The usage of each pin is as follows.
         {   // ILI9342c
           board = board_t::board_M5ToughC5;
           ESP_LOGI(LIBRARY_NAME, "[Autodetect] board_M5ToughC5");
+
+          // ボードが確定したので、常用するハードウェアポートへバスを引き継ぐ
+          // (バックライトとタッチがこのポートを使う)
+          lgfx::i2c::release(probe_i2c_port);
+          lgfx::i2c::init(i2c_port, toughc5_i2c_sda, toughc5_i2c_scl);
 
           bus_spi->release();
           bus_cfg.freq_write = 20000000;
@@ -3319,7 +3335,8 @@ The usage of each pin is as follows.
         }
         bus_spi->release();
       }
-      lgfx::i2c::release(i2c_port);
+      // ここへ来るのはボード不成立の場合のみ。ソフトウェアポートしか触れていない
+      lgfx::i2c::release(probe_i2c_port);
       for (auto &bup : backup_pins) { bup.restore(); }
     }
 

--- a/src/lgfx/v1/platforms/esp32/Bus_I2C.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_I2C.cpp
@@ -119,6 +119,7 @@ namespace lgfx
 
   void Bus_I2C::wait(void)
   {
+    if (_cfg.i2c_port < 0) { return; } // a software port transfers synchronously
 #if I2C_NUM_MAX > 1
     auto dev = (_cfg.i2c_port == 0) ? &I2C0 : &I2C1;
 #else
@@ -130,6 +131,7 @@ namespace lgfx
 
   bool Bus_I2C::busy(void) const
   {
+    if (_cfg.i2c_port < 0) { return false; } // a software port transfers synchronously
 #if I2C_NUM_MAX > 1
     auto dev = (_cfg.i2c_port == 0) ? &I2C0 : &I2C1;
 #else

--- a/src/lgfx/v1/platforms/esp32/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl = 22;
       int16_t pin_sda = 21;
-      uint8_t i2c_port = 0;      // e.g. ESP32 0=I2C_NUM_0 / 1=I2C_NUM_1
+      int8_t i2c_port = 0;       // e.g. ESP32 0=I2C_NUM_0 / 1=I2C_NUM_1 / negative=software
       uint8_t i2c_addr = 0x3C;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -630,6 +630,14 @@ namespace lgfx
 #endif
     static spi_device_handle_t _spi_dev_handle[spi_periph_num] = {nullptr};
 
+// ------------------------------------------------------------------------
+// Software SPI ( soft_spi.inl ), reached through the negative host numbers.
+
+#define LGFX_INTERNAL_SOFT_SPI
+#include "../soft_spi.inl"
+
+// ------------------------------------------------------------------------
+
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
     {
       return init(spi_host, spi_sclk, spi_miso, spi_mosi, 0); // SPI_DMA_CH_AUTO;
@@ -638,6 +646,11 @@ namespace lgfx
     cpp::result<void, error_t> init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi, int dma_channel)
     {
 //ESP_LOGI("LGFX","spi::init host:%d, sclk:%d, miso:%d, mosi:%d, dma:%d", spi_host, spi_sclk, spi_miso, spi_mosi, dma_channel);
+      if (spi_host < 0)
+      {
+        return soft_spi_init(spi_host, spi_sclk, spi_miso, spi_mosi);
+      }
+
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
 
@@ -725,6 +738,7 @@ namespace lgfx
     cpp::result<void, error_t> initQuad(int spi_host, int spi_sclk, int spi_io0, int spi_io1, int spi_io2, int spi_io3, int dma_channel)
     {
       //ESP_LOGI("LGFX","spi::init host:%d, sclk:%d, miso:%d, mosi:%d, dma:%d", spi_host, spi_sclk, spi_miso, spi_mosi, dma_channel);
+      if (spi_host < 0) { return cpp::fail(error_t::invalid_arg); }  // the software hosts are single bit only
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
 
@@ -800,6 +814,11 @@ namespace lgfx
     void release(int spi_host)
     {
 //ESP_LOGI("LGFX","spi::release");
+      if (spi_host < 0)
+      {
+        soft_spi_release(spi_host);
+        return;
+      }
 #if defined (ARDUINO) && __has_include (<SPI.h>) // Arduino ESP32
       if (_spi_handle[spi_host] != nullptr)
       {
@@ -824,6 +843,11 @@ namespace lgfx
 
     void beginTransaction(int spi_host)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_beginTransaction(spi_host);
+        return;
+      }
 #if defined (ARDUINO) // Arduino ESP32
       spiSimpleTransaction(_spi_handle[spi_host]);
 #else // ESP-IDF
@@ -840,6 +864,11 @@ namespace lgfx
 
     void beginTransaction(int spi_host, uint32_t freq, int spi_mode)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_beginTransaction(spi_host, freq, spi_mode);
+        return;
+      }
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
       uint32_t clkdiv = FreqToClockDiv(getApbFrequency(), freq);
@@ -885,6 +914,7 @@ namespace lgfx
 
     void endTransaction(int spi_host)
     {
+      if (spi_host < 0) { return; }  // a software host holds nothing to release
       if (_spi_dev_handle[spi_host]) {
 #if defined (ARDUINO) // Arduino ESP32
         spiEndTransaction(_spi_handle[spi_host]);
@@ -902,6 +932,11 @@ namespace lgfx
 
     void writeBytes(int spi_host, const uint8_t* data, size_t len)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_writeBytes(spi_host, data, len);
+        return;
+      }
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
       if (len > 64) len = 64;
@@ -913,6 +948,11 @@ namespace lgfx
 
     void readBytes(int spi_host, uint8_t* data, size_t len)
     {
+      if (spi_host < 0)
+      {
+        soft_spi_readBytes(spi_host, data, len);
+        return;
+      }
       uint32_t spi_port = (spi_host + 1);
       (void)spi_port;
       if (len > 64) len = 64;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1270,6 +1270,27 @@ namespace lgfx
     };
     i2c_context_t i2c_context[I2C_NUM_MAX];
 
+    static inline bool isSoftPort(int i2c_port) { return i2c_port < 0; }
+
+// ------------------------------------------------------------------------
+// Software I2C ( soft_i2c.inl ), reached through the negative port numbers.
+// pinMode() here puts a pin in open drain output with the latch high and the
+// input stage enabled, so a line is driven and released by toggling the latch
+// alone; the direction changing default of the fragment is not needed.
+
+#define SOFT_I2C_LINE_LO(pin) gpio_lo(pin)
+#define SOFT_I2C_LINE_HI(pin) gpio_hi(pin)
+#define SOFT_I2C_LOCK(ctx) do { \
+    if ((ctx).lock_handle == nullptr) { (ctx).lock_handle = xSemaphoreCreateMutex(); } \
+    xSemaphoreTake((SemaphoreHandle_t)(ctx).lock_handle, portMAX_DELAY); \
+  } while (0)
+#define SOFT_I2C_UNLOCK(ctx) xSemaphoreGive((SemaphoreHandle_t)(ctx).lock_handle)
+#define SOFT_I2C_YIELD() taskYIELD()
+#define LGFX_INTERNAL_SOFT_I2C
+#include "../soft_i2c.inl"
+
+// ------------------------------------------------------------------------
+
 #if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
     /// Hand a pin back from the low power IO domain.
     /// A pin routed to the low power I2C keeps that routing across a reset, because it is
@@ -1497,6 +1518,7 @@ namespace lgfx
 
     cpp::result<void, error_t> release(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_release(i2c_port); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_context[i2c_port].initialized)
       {
@@ -1558,12 +1580,13 @@ namespace lgfx
 
     cpp::result<void, error_t> setPins(int i2c_port, int pin_sda, int pin_scl)
     {
-      if ((i2c_port >= I2C_NUM_MAX)
-       || ((uint32_t)pin_scl >= GPIO_NUM_MAX)
+      if (((uint32_t)pin_scl >= GPIO_NUM_MAX)
        || ((uint32_t)pin_sda >= GPIO_NUM_MAX))
       {
         return cpp::fail(error_t::invalid_arg);
       }
+      if (isSoftPort(i2c_port)) { return soft_i2c_setPins(i2c_port, pin_sda, pin_scl); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
 
       if (i2c_context[i2c_port].initialized
        && i2c_context[i2c_port].pin_scl == (gpio_num_t)pin_scl
@@ -1602,20 +1625,25 @@ namespace lgfx
 
     cpp::result<int, error_t> getPinSDA(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_getPinSDA(i2c_port); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       return i2c_context[i2c_port].pin_sda;
     }
 
     cpp::result<int, error_t> getPinSCL(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_getPinSCL(i2c_port); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       return i2c_context[i2c_port].pin_scl;
     }
 
     cpp::result<void, error_t> init(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_init(i2c_port); }
+      if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       gpio_num_t pin_sda = i2c_context[i2c_port].pin_sda;
       gpio_num_t pin_scl = i2c_context[i2c_port].pin_scl;
-      if ((i2c_port >= I2C_NUM_MAX)
-       || ((uint32_t)pin_scl >= GPIO_NUM_MAX)
+      if (((uint32_t)pin_scl >= GPIO_NUM_MAX)
        || ((uint32_t)pin_sda >= GPIO_NUM_MAX))
       {
         return cpp::fail(error_t::invalid_arg);
@@ -1706,6 +1734,7 @@ namespace lgfx
 
     cpp::result<void, error_t> restart(int i2c_port, int i2c_addr, uint32_t freq, bool read)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_restart(i2c_port, i2c_addr, freq, read); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_addr < I2C_7BIT_ADDR_MIN || i2c_addr > I2C_10BIT_ADDR_MAX) return cpp::fail(error_t::invalid_arg);
 
@@ -1832,8 +1861,8 @@ namespace lgfx
 
     cpp::result<void, error_t> beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_beginTransaction(i2c_port, i2c_addr, freq, read); }
       if (i2c_port >= I2C_NUM_MAX) return cpp::fail(error_t::invalid_arg);
-
       if ((uint32_t)i2c_context[i2c_port].pin_sda >= GPIO_NUM_MAX || (uint32_t)i2c_context[i2c_port].pin_scl >= GPIO_NUM_MAX) return cpp::fail(error_t::invalid_arg);
 
 //ESP_LOGI("LGFX", "i2c::beginTransaction : port:%d / addr:%02x / freq:%d / rw:%d", i2c_port, i2c_addr, freq, read);
@@ -1922,12 +1951,14 @@ namespace lgfx
 
     cpp::result<void, error_t> endTransaction(int i2c_port)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_endTransaction(i2c_port); }
       if (i2c_port >= I2C_NUM_MAX) return cpp::fail(error_t::invalid_arg);
       return i2c_wait(i2c_port, true);
     }
 //*/
     cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_writeBytes(i2c_port, data, length); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_context[i2c_port].state.has_error()) { return cpp::fail(i2c_context[i2c_port].state.error()); }
       if (i2c_context[i2c_port].state != i2c_context_t::state_write) { return cpp::fail(error_t::mode_mismatch); }
@@ -1964,8 +1995,9 @@ namespace lgfx
       return res;
     }
 
-    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *readdata, size_t length, bool last_nack = false)
+    cpp::result<void, error_t> readBytes(int i2c_port, uint8_t *readdata, size_t length, bool last_nack)
     {
+      if (isSoftPort(i2c_port)) { return soft_i2c_readBytes(i2c_port, readdata, length, last_nack); }
       if (i2c_port >= I2C_NUM_MAX) { return cpp::fail(error_t::invalid_arg); }
       if (i2c_context[i2c_port].state.has_error()) { return cpp::fail(i2c_context[i2c_port].state.error()); }
       if (i2c_context[i2c_port].state != i2c_context_t::state_read) { return cpp::fail(error_t::mode_mismatch); }

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -938,6 +938,83 @@ namespace lgfx
  #define I2C_ACK_ERR_INT_RAW_M I2C_NACK_INT_RAW_M
 #endif
 
+// From the ESP32-C6 on, some chips carry a low power I2C in addition to the normal ones,
+// and SOC_I2C_NUM counts both of them. SOC_HP_I2C_NUM / SOC_LP_I2C_NUM tell them apart,
+// but they only exist in recent ESP-IDF, so the chips with a single high power port have
+// to be named when they are missing.
+#if defined ( SOC_HP_I2C_NUM )
+ #define LGFX_HP_I2C_NUM SOC_HP_I2C_NUM
+#elif defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 )
+ #define LGFX_HP_I2C_NUM 1
+#else
+ #define LGFX_HP_I2C_NUM SOC_I2C_NUM
+#endif
+
+// ESP-IDF numbers the low power ports after all the high power ones, so the first low
+// power port index is the number of high power ports. ( see i2c_port_t in hal/i2c_types.h )
+#if defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 )
+ #define LGFX_LP_I2C_NUM SOC_LP_I2C_NUM
+ #define LGFX_LP_I2C_PORT LGFX_HP_I2C_NUM
+#else
+ #define LGFX_LP_I2C_NUM 0
+#endif
+
+    /// True if this port index belongs to the low power I2C.
+    static inline bool isLpPort(int i2c_port)
+    {
+#if LGFX_LP_I2C_NUM > 0
+      return i2c_port >= LGFX_LP_I2C_PORT;
+#else
+      (void)i2c_port;
+      return false;
+#endif
+    }
+
+    /// Hardware FIFO depth of this port. The low power I2C has a shallower FIFO than the
+    /// normal one, so this cannot be a single constant for the whole chip.
+    static inline uint32_t getFifoLen(int i2c_port)
+    {
+#if LGFX_LP_I2C_NUM > 0 && defined ( SOC_LP_I2C_FIFO_LEN )
+      if (isLpPort(i2c_port)) { return SOC_LP_I2C_FIFO_LEN; }
+#else
+      (void)i2c_port;
+#endif
+#if defined ( SOC_I2C_FIFO_LEN )
+      return SOC_I2C_FIFO_LEN;
+#else
+      return 32;
+#endif
+    }
+
+    /// Clock feeding the SCL divider of this port [Hz].
+    /// This is not a property of the chip alone: the low power I2C runs from its own
+    /// clock, and on the older chips the normal one follows the CPU frequency.
+    static inline uint32_t getSourceClock(int i2c_port)
+    {
+#if LGFX_LP_I2C_NUM > 0
+      if (isLpPort(i2c_port))
+      { // Both selectable sources of the low power I2C are 20MHz:
+        // LP_FAST ( RC fast, nominal 20MHz ) and XTAL_D2 ( 40MHz crystal divided by 2 ).
+        return 20 * 1000 * 1000;
+      }
+#else
+      (void)i2c_port;
+#endif
+
+#if defined (CONFIG_IDF_TARGET_ESP32C2) || defined (CONFIG_IDF_TARGET_ESP32C3) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32S3) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+      return 40 * 1000 * 1000; // XTAL clock
+#else
+      rtc_cpu_freq_config_t cpu_freq_conf;
+      rtc_clk_cpu_freq_get_config(&cpu_freq_conf);
+      if (cpu_freq_conf.freq_mhz < 80)
+      { // The source follows the CPU frequency here, so it has to be read every time
+        // rather than cached when the port is initialized.
+        return (cpu_freq_conf.source_freq_mhz * 1000000) / cpu_freq_conf.div;
+      }
+      return 80 * 1000 * 1000;
+#endif
+    }
+
 #if !defined ( I2C_CLOCK_SRC_ATOMIC )
   #if __cplusplus <= 201103L
     #define LGFX_PERIPH_MODULE_T periph_module_t
@@ -948,7 +1025,7 @@ namespace lgfx
     __attribute__ ((unused))
         static LGFX_PERIPH_MODULE_T getPeriphModule(int num)
     {
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       return PERIPH_I2C0_MODULE;
 #else
       return num == 0 ? PERIPH_I2C0_MODULE : PERIPH_I2C1_MODULE;
@@ -960,7 +1037,7 @@ namespace lgfx
 
     static i2c_dev_t* getDev(int num)
     {
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       return &I2C0;
 #else
       return num == 0 ? &I2C0 : &I2C1;
@@ -1144,7 +1221,7 @@ namespace lgfx
   #endif
  #endif
 
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
         auto twowire = &Wire;
 #else
         auto twowire = ((dev == &I2C0) ? &Wire : &Wire1);
@@ -1378,7 +1455,7 @@ namespace lgfx
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
   #if defined ARDUINO_ESP32_GIT_VER
     #if ARDUINO_ESP32_GIT_VER != 0x44c11981
-      #if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+      #if LGFX_HP_I2C_NUM == 1
         auto twowire = &Wire;
       #else
         auto twowire = ((i2c_port == 0) ? &Wire : &Wire1);
@@ -1437,7 +1514,7 @@ namespace lgfx
  #endif
  #if defined ( USE_TWOWIRE_SETPINS )
 
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       auto twowire = &Wire;
 #else
       auto twowire = ((i2c_port == 0) ? &Wire : &Wire1);
@@ -1477,7 +1554,7 @@ namespace lgfx
       i2c_stop(i2c_port);
 
 #if defined ( ARDUINO ) && __has_include (<Wire.h>)
-#if SOC_I2C_NUM == 1 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C5 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32C61
+#if LGFX_HP_I2C_NUM == 1
       auto twowire = &Wire;
 #else
       auto twowire = ((i2c_port == 0) ? &Wire : &Wire1);
@@ -1561,22 +1638,7 @@ namespace lgfx
       {
         i2c_context[i2c_port].freq = freq;
         static constexpr uint32_t MIN_I2C_CYCLE = 35;
-#if defined (CONFIG_IDF_TARGET_ESP32C2) || defined (CONFIG_IDF_TARGET_ESP32C3) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32S3) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
-        uint32_t src_clock = 40 * 1000 * 1000; // XTAL clock
-#else
-        rtc_cpu_freq_config_t cpu_freq_conf;
-        rtc_clk_cpu_freq_get_config(&cpu_freq_conf);
-        uint32_t src_clock = 80 * 1000 * 1000;
-        if (cpu_freq_conf.freq_mhz < 80)
-        {
-          src_clock = (cpu_freq_conf.source_freq_mhz * 1000000) / cpu_freq_conf.div;
-        }
-// ESP_LOGI("LGFX", "i2c::restart : port:%d / addr:%02x / freq:%d / rw:%d", i2c_port, i2c_addr, freq, read);
-// ESP_LOGI("LGFX", "cpu_freq_conf.div             :%d", cpu_freq_conf.div);
-// ESP_LOGI("LGFX", "cpu_freq_conf.freq_mhz        :%d", cpu_freq_conf.freq_mhz);
-// ESP_LOGI("LGFX", "cpu_freq_conf.source          :%d", cpu_freq_conf.source);
-// ESP_LOGI("LGFX", "cpu_freq_conf.source_freq_mhz :%d", cpu_freq_conf.source_freq_mhz);
-#endif
+        uint32_t src_clock = getSourceClock(i2c_port);
 
         auto cycle = std::min<uint32_t>(32767u, std::max(MIN_I2C_CYCLE, (src_clock / (freq + 1) + 1)));
         freq = src_clock / cycle;
@@ -1752,10 +1814,10 @@ namespace lgfx
       cpp::result<void, error_t> res {};
       if (!length) return res;
 
-      static constexpr int txfifo_limit = 32;
+      const uint32_t txfifo_limit = getFifoLen(i2c_port);
       auto dev = getDev(i2c_port);
       auto fifo_addr = getFifoAddr(i2c_port);
-      size_t len = ((length - 1) & (txfifo_limit-1)) + 1;
+      size_t len = ((length - 1) % txfifo_limit) + 1;
       do
       {
         res = i2c_wait(i2c_port);
@@ -1791,6 +1853,7 @@ namespace lgfx
       if (!length) return res;
 
       static constexpr uint32_t intmask = I2C_ACK_ERR_INT_RAW_M | I2C_TIME_OUT_INT_RAW_M | I2C_END_DETECT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M;
+      const uint32_t rxfifo_limit = getFifoLen(i2c_port);
       auto fifo_addr = getFifoAddr(i2c_port);
       auto dev = getDev(i2c_port);
 
@@ -1811,7 +1874,7 @@ namespace lgfx
           break;
         }
 
-        len = length < 32 ? length : 32;
+        len = length < rxfifo_limit ? length : rxfifo_limit;
 #if defined ( CONFIG_IDF_TARGET_ESP32 ) || !defined ( CONFIG_IDF_TARGET )
         // workaround for ESP32 i2c bug.
         if (last_nack && len == length && len > 1) { len -= 1; }

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -952,9 +952,20 @@ namespace lgfx
 
 // ESP-IDF numbers the low power ports after all the high power ones, so the first low
 // power port index is the number of high power ports. ( see i2c_port_t in hal/i2c_types.h )
-#if defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 )
+//
+// Bringing a low power port up is left to the ESP-IDF driver: there is no TwoWire for it,
+// and the pads reach the peripheral differently depending on the chip ( a fixed LP IO MUX
+// function on some, the LP GPIO matrix on others ). The driver already knows which, so it
+// is asked to open the bus and the registers are taken over afterwards, exactly as this
+// code does for the normal ports.
+#if defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 ) && __has_include ( <driver/i2c_master.h> ) \
+ && defined ( ESP_IDF_VERSION_VAL ) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
  #define LGFX_LP_I2C_NUM SOC_LP_I2C_NUM
  #define LGFX_LP_I2C_PORT LGFX_HP_I2C_NUM
+ // The default source is the RC oscillator, which drifts with temperature. XTAL_D2 is a
+ // divided crystal, so the SCL frequency comes out as asked.
+ #define LGFX_LP_I2C_SCLK LP_I2C_SCLK_XTAL_D2
+ #include <esp_clk_tree.h>
 #else
  #define LGFX_LP_I2C_NUM 0
 #endif
@@ -993,8 +1004,15 @@ namespace lgfx
     {
 #if LGFX_LP_I2C_NUM > 0
       if (isLpPort(i2c_port))
-      { // Both selectable sources of the low power I2C are 20MHz:
-        // LP_FAST ( RC fast, nominal 20MHz ) and XTAL_D2 ( 40MHz crystal divided by 2 ).
+      { // Ask the clock tree rather than assuming a figure: which source the low power
+        // port runs from is a choice made when the bus is opened, and the two are not
+        // the same clock even where they happen to share a nominal frequency.
+        uint32_t hz = 0;
+        if (ESP_OK == esp_clk_tree_src_get_freq_hz((soc_module_clk_t)LGFX_LP_I2C_SCLK
+                    , ESP_CLK_TREE_SRC_FREQ_PRECISION_APPROX, &hz) && hz)
+        {
+          return hz;
+        }
         return 20 * 1000 * 1000;
       }
 #else
@@ -1037,6 +1055,12 @@ namespace lgfx
 
     static i2c_dev_t* getDev(int num)
     {
+#if LGFX_LP_I2C_NUM > 0
+      // The register layout of the low power I2C matches the normal one, which is why
+      // ESP-IDF publishes it as an i2c_dev_t as well. Everything below the port lookup
+      // therefore works on it unchanged.
+      if (isLpPort(num)) { return &LP_I2C; }
+#endif
 #if LGFX_HP_I2C_NUM == 1
       return &I2C0;
 #else
@@ -1235,8 +1259,10 @@ namespace lgfx
 #endif
       }
 
-#if defined ( ARDUINO ) && __has_include (<Wire.h>)
-#elif __has_include(<driver/i2c_master.h>)
+// A low power port is opened through the ESP-IDF driver even in an Arduino build, where
+// the normal ports go through TwoWire, so the handle is needed in both cases.
+#if __has_include(<driver/i2c_master.h>) \
+ && ( LGFX_LP_I2C_NUM > 0 || !( defined ( ARDUINO ) && __has_include (<Wire.h>) ) )
       i2c_master_bus_handle_t i2c_bus_handle = nullptr;
 #endif
     private:
@@ -1244,8 +1270,32 @@ namespace lgfx
     };
     i2c_context_t i2c_context[I2C_NUM_MAX];
 
+#if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
+    /// Hand a pin back from the low power IO domain.
+    /// A pin routed to the low power I2C keeps that routing across a reset, because it is
+    /// held in the low power domain rather than by the CPU. Any later attempt to drive it
+    /// from a normal port then finds a pad that no longer reaches the peripheral, and the
+    /// bus looks dead for reasons nothing in the running program explains. Releasing it
+    /// here makes taking a pin over idempotent, whether or not the previous user shut
+    /// down in an orderly way.
+    static void releaseLpPad(gpio_num_t pin)
+    {
+      if ((int)pin >= 0 && rtc_gpio_is_valid_gpio(pin))
+      {
+        rtc_gpio_deinit(pin);
+      }
+    }
+#endif
+
     static void set_pin(i2c_port_t i2c_num, gpio_num_t pin_sda, gpio_num_t pin_scl)
     {
+#if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
+      // Callers keep the low power ports away from here, so reaching this point means the
+      // pins are wanted for a normal port and any low power routing left on them, possibly
+      // by a previous run, has to go. ( see releaseLpPad )
+      releaseLpPad(pin_sda);
+      releaseLpPad(pin_scl);
+#endif
 #if __has_include(<driver/i2c_master.h>)
       if ((int8_t)pin_sda >= 0) {
         gpio_set_level(pin_sda, true);
@@ -1451,6 +1501,25 @@ namespace lgfx
       if (i2c_context[i2c_port].initialized)
       {
         i2c_context[i2c_port].initialized = false;
+#if LGFX_LP_I2C_NUM > 0
+        if (isLpPort(i2c_port))
+        { // Opened through the ESP-IDF driver in init(), so it is closed the same way.
+          auto bus_handle = i2c_context[i2c_port].i2c_bus_handle;
+          if (bus_handle) {
+            i2c_context[i2c_port].i2c_bus_handle = nullptr;
+            i2c_del_master_bus(bus_handle);
+          }
+ #if SOC_RTCIO_PIN_COUNT > 0
+          // The pins have to be handed back explicitly: their routing lives in the low
+          // power domain and would otherwise outlive this program, leaving them unusable
+          // from a normal port even after a reset. ( see releaseLpPad )
+          releaseLpPad(i2c_context[i2c_port].pin_sda);
+          releaseLpPad(i2c_context[i2c_port].pin_scl);
+ #endif
+        }
+        else
+#endif
+        {
 #if defined ( ARDUINO ) && __has_include (<Wire.h>) && defined ( ESP_IDF_VERSION_VAL )
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
   #if defined ARDUINO_ESP32_GIT_VER
@@ -1473,6 +1542,7 @@ namespace lgfx
 #else
         i2c_periph_disable(i2c_port);
 #endif
+        }
         if ((int)i2c_context[i2c_port].pin_scl >= 0)
         {
           pinMode(i2c_context[i2c_port].pin_scl, pin_mode_t::input_pullup);
@@ -1506,6 +1576,11 @@ namespace lgfx
       release(i2c_port).has_value();
       i2c_context[i2c_port].pin_scl = (gpio_num_t)pin_scl;
       i2c_context[i2c_port].pin_sda = (gpio_num_t)pin_sda;
+#if LGFX_LP_I2C_NUM > 0
+      // The TwoWire instances belong to the normal ports; a low power port has none,
+      // and handing these pins to one would redirect that port to them.
+      if (isLpPort(i2c_port)) { return {}; }
+#endif
 #if defined ( ARDUINO ) && __has_include (<Wire.h>)
  #if defined ( ESP_IDF_VERSION_VAL )
   #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(3, 3, 0)
@@ -1552,6 +1627,35 @@ namespace lgfx
       }
 
       i2c_stop(i2c_port);
+
+#if LGFX_LP_I2C_NUM > 0
+      if (isLpPort(i2c_port))
+      {
+        i2c_master_bus_config_t bus_config;
+        memset(&bus_config, 0, sizeof(i2c_master_bus_config_t));
+        bus_config.i2c_port = i2c_port;
+        bus_config.sda_io_num = pin_sda;
+        bus_config.scl_io_num = pin_scl;
+        bus_config.lp_source_clk = LGFX_LP_I2C_SCLK;
+        bus_config.glitch_ignore_cnt = 7;
+        bus_config.flags.enable_internal_pullup = true;
+        bus_config.intr_priority = 1;
+
+        i2c_master_bus_handle_t bus_handle = nullptr;
+        if (ESP_OK != i2c_new_master_bus(&bus_config, &bus_handle))
+        { // The pins of the low power port are constrained: they have to be LP IO, and on
+          // the chips without an LP GPIO matrix they are a fixed pair.
+          return cpp::fail(error_t::invalid_arg);
+        }
+        i2c_context[i2c_port].i2c_bus_handle = bus_handle;
+        i2c_context[i2c_port].initialized = true;
+
+        // The pads are already routed to the peripheral by the call above, and they do not
+        // go through the normal GPIO matrix that set_pin() drives, so it is not called.
+        i2c_context[i2c_port].save_reg(getDev(i2c_port));
+        return {};
+      }
+#endif
 
 #if defined ( ARDUINO ) && __has_include (<Wire.h>)
 #if LGFX_HP_I2C_NUM == 1
@@ -1757,7 +1861,15 @@ namespace lgfx
       }
       i2c_context[i2c_port].save_reg(dev);
 
-      set_pin((i2c_port_t)i2c_port, i2c_context[i2c_port].pin_sda, i2c_context[i2c_port].pin_scl);
+#if LGFX_LP_I2C_NUM > 0
+      // A low power port reaches its pads through the low power IO domain, which set_pin()
+      // knows nothing about: routing them through the normal GPIO matrix here would
+      // disconnect the port from its own pins on every transaction.
+      if (!isLpPort(i2c_port))
+#endif
+      {
+        set_pin((i2c_port_t)i2c_port, i2c_context[i2c_port].pin_sda, i2c_context[i2c_port].pin_scl);
+      }
 
 #if SOC_I2C_SUPPORT_HW_FSM_RST
       dev->ctr.fsm_rst = 1;
@@ -1778,8 +1890,16 @@ namespace lgfx
       ctrl_reg.val = 0;
       ctrl_reg.ms_mode = 1;       // master mode
       ctrl_reg.clk_en = 1;
-      ctrl_reg.sda_force_out = 1;
-      ctrl_reg.scl_force_out = 1;
+#if LGFX_LP_I2C_NUM > 0
+      // The low power controller reaches the bus only through its internal open drain
+      // mode ( sda_force_out = 0 ): with the outputs forced, the state machine runs to
+      // completion without ever driving the lines, so no device can respond.
+      if (!isLpPort(i2c_port))
+#endif
+      {
+        ctrl_reg.sda_force_out = 1;
+        ctrl_reg.scl_force_out = 1;
+      }
       dev->ctr.val = ctrl_reg.val;
 // ---------- i2c_ll_master_init
       typeof(dev->fifo_conf) fifo_conf_reg;

--- a/src/lgfx/v1/platforms/sdl/Bus_I2C.hpp
+++ b/src/lgfx/v1/platforms/sdl/Bus_I2C.hpp
@@ -35,7 +35,7 @@ namespace lgfx
       uint32_t freq_read = 400000;
       int16_t pin_scl = 22;
       int16_t pin_sda = 21;
-      uint8_t i2c_port = 0;
+      int8_t i2c_port = 0;
       uint8_t i2c_addr = 0x3C;
       uint32_t prefix_cmd = 0x00;
       uint32_t prefix_data = 0x40;

--- a/src/lgfx/v1/platforms/soft_i2c.inl
+++ b/src/lgfx/v1/platforms/soft_i2c.inl
@@ -1,0 +1,409 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+// I2C on plain GPIO, selected by a negative port number: port -1 is slot 0,
+// port -2 is slot 1. It reaches a bus without claiming a peripheral unit, for
+// when every unit is taken or when touching one is undesirable.
+//
+// This file is not a header but a code fragment: a platform implementation
+// includes it inside its i2c namespace, and delegates to the soft_i2c_*()
+// functions at the top of each public function when the port is negative.
+// Everything here has internal linkage, so nothing beyond the negative port
+// convention becomes part of the library interface.
+//
+// The transaction semantics mirror the peripheral paths: an unacknowledged
+// address surfaces at the next operation or at endTransaction, not at
+// beginTransaction. On a failure the bus is stopped and the lock released
+// right away, and the stored error is reported (and cleared) later.
+// Clock stretching is honored wherever SCL is released.
+#if !defined ( LGFX_INTERNAL_SOFT_I2C )
+ #error "soft_i2c.inl is an implementation fragment of the i2c namespace; it cannot be included directly."
+#endif
+
+// An I2C line is only ever driven low or released, never driven high. The
+// default implementation releases by turning the pin back into an input and
+// drives by turning it into an output whose latch was parked low, which works
+// on any platform. A platform whose pinMode() gives an input mode an open
+// drain output stage (esp32) overrides these with plain latch toggles and
+// skips the direction changes.
+#if !defined ( SOFT_I2C_LINE_LO )
+ #define SOFT_I2C_LINE_LO(pin)   do { gpio_lo(pin); pinMode(pin, pin_mode_t::output); } while (0)
+ #define SOFT_I2C_LINE_HI(pin)   pinMode(pin, pin_mode_t::input_pullup)
+#endif
+
+// Serialization of the transactions on a slot. A platform with an RTOS wraps
+// a mutex over the lock_handle member; the default is single threaded.
+#if !defined ( SOFT_I2C_LOCK )
+ #define SOFT_I2C_LOCK(ctx)
+ #define SOFT_I2C_UNLOCK(ctx)
+#endif
+
+// Called while waiting out a stretched clock.
+#if !defined ( SOFT_I2C_YIELD )
+ #if defined ( ARDUINO )
+  #define SOFT_I2C_YIELD() yield()
+ #else
+  #define SOFT_I2C_YIELD()
+ #endif
+#endif
+
+//----------------------------------------------------------------------------
+
+    static constexpr int soft_i2c_port_count = 2;
+
+    static constexpr int soft_i2c_7bit_addr_min = 0x08;
+    static constexpr int soft_i2c_7bit_addr_max = 0x77;
+    static constexpr int soft_i2c_10bit_addr_max = 1023;
+
+    struct soft_i2c_context_t
+    {
+      enum state_t
+      {
+        state_disconnect,
+        state_write,
+        state_read
+      };
+      cpp::result<state_t, error_t> state;
+      void* lock_handle = nullptr;  // storage for the SOFT_I2C_LOCK hooks
+      int pin_sda = -1;
+      int pin_scl = -1;
+      uint32_t freq = 0;
+      uint32_t half_us = 0;  // 0 = unthrottled
+      bool initialized = false;
+    };
+    static soft_i2c_context_t soft_i2c_context[soft_i2c_port_count];
+
+    static inline bool soft_i2c_valid_port(int i2c_port) { return -soft_i2c_port_count <= i2c_port && i2c_port < 0; }
+    static inline soft_i2c_context_t& soft_i2c_ctx(int i2c_port) { return soft_i2c_context[~i2c_port]; }
+
+    static inline void soft_i2c_half_wait(uint32_t half_us)
+    { if (half_us) { delayMicroseconds(half_us); } }
+
+    static inline void soft_i2c_set_freq(soft_i2c_context_t& ctx, uint32_t freq)
+    {
+      if (freq == 0) { freq = 100000; }  // an unset frequency falls back to the usual default
+      ctx.freq = freq;
+      // Rounded up: the throttled clock must not come out above the request.
+      ctx.half_us = (freq >= 500000) ? 0 : (500000 + freq - 1) / freq;
+    }
+
+    /// Release SCL and wait for it to actually rise, honoring clock stretching.
+    static inline bool soft_i2c_scl_hi(const soft_i2c_context_t& ctx)
+    {
+      SOFT_I2C_LINE_HI(ctx.pin_scl);
+      soft_i2c_half_wait(ctx.half_us);
+      if (gpio_in(ctx.pin_scl)) { return true; }
+      auto us = micros();
+      do
+      {
+        SOFT_I2C_YIELD();
+        if (gpio_in(ctx.pin_scl)) { return true; }
+      } while ((micros() - us) < 13000); // the same order as a peripheral timeout
+      return false;
+    }
+
+    /// Returns true when the byte was acknowledged.
+    static inline bool soft_i2c_write_byte(const soft_i2c_context_t& ctx, uint8_t data)
+    {
+      size_t i = 0;
+      do
+      {
+        SOFT_I2C_LINE_LO(ctx.pin_scl);
+        if (data & 0x80) { SOFT_I2C_LINE_HI(ctx.pin_sda); } else { SOFT_I2C_LINE_LO(ctx.pin_sda); }
+        data <<= 1;
+        soft_i2c_half_wait(ctx.half_us);
+        if (!soft_i2c_scl_hi(ctx)) { return false; }
+      } while (++i < 8);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);  // release the data line for the acknowledge
+      soft_i2c_half_wait(ctx.half_us);
+      if (!soft_i2c_scl_hi(ctx)) { return false; }
+      bool ack = !gpio_in(ctx.pin_sda);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      return ack;
+    }
+
+    static inline bool soft_i2c_read_byte(const soft_i2c_context_t& ctx, uint8_t* data, bool ack)
+    {
+      uint_fast8_t byte = 0;
+      SOFT_I2C_LINE_HI(ctx.pin_sda);  // released: the device drives the data line
+      size_t i = 0;
+      do
+      {
+        SOFT_I2C_LINE_LO(ctx.pin_scl);
+        soft_i2c_half_wait(ctx.half_us);
+        if (!soft_i2c_scl_hi(ctx)) { return false; }
+        byte = (byte << 1) + (gpio_in(ctx.pin_sda) ? 1 : 0);
+      } while (++i < 8);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      if (ack) { SOFT_I2C_LINE_LO(ctx.pin_sda); } else { SOFT_I2C_LINE_HI(ctx.pin_sda); }
+      soft_i2c_half_wait(ctx.half_us);
+      if (!soft_i2c_scl_hi(ctx)) { return false; }
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      *data = byte;
+      return true;
+    }
+
+    /// Returns false when the clock could not be released for the stop condition.
+    static inline bool soft_i2c_stop_cond(const soft_i2c_context_t& ctx)
+    {
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      SOFT_I2C_LINE_LO(ctx.pin_sda);
+      soft_i2c_half_wait(ctx.half_us);
+      bool ok = soft_i2c_scl_hi(ctx);
+      soft_i2c_half_wait(ctx.half_us);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      soft_i2c_half_wait(ctx.half_us);
+      return ok;
+    }
+
+    /// Free a bus whose device was left mid transfer (e.g. by a reset) and holds
+    /// the data line, by clocking the leftover bits out.
+    static inline void soft_i2c_recover(const soft_i2c_context_t& ctx)
+    {
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      size_t i = 0;
+      while (!gpio_in(ctx.pin_sda) && ++i <= 9)
+      {
+        SOFT_I2C_LINE_LO(ctx.pin_scl);
+        soft_i2c_half_wait(ctx.half_us);
+        soft_i2c_scl_hi(ctx);
+      }
+      soft_i2c_stop_cond(ctx);
+    }
+
+    /// Ends a transfer on a failure. The bus is stopped and the lock released
+    /// right away; the error is stored so that it surfaces from the following
+    /// operation or from endTransaction, as it does on a peripheral path.
+    static inline void soft_i2c_abort(soft_i2c_context_t& ctx)
+    {
+      soft_i2c_stop_cond(ctx);
+      ctx.state = cpp::fail(error_t::connection_lost);
+      SOFT_I2C_UNLOCK(ctx);
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_send_address(soft_i2c_context_t& ctx, int i2c_addr, bool read)
+    {
+      bool ack;
+      if (i2c_addr <= soft_i2c_7bit_addr_max)
+      {
+        ack = soft_i2c_write_byte(ctx, i2c_addr << 1 | (read ? 1 : 0));
+      }
+      else
+      {
+        ack = soft_i2c_write_byte(ctx, 0xF0 | (i2c_addr >> 8) << 1)
+           && soft_i2c_write_byte(ctx, i2c_addr & 0xFF);
+        if (ack && read)
+        { // A 10 bit read re-addresses the high byte in read mode.
+          SOFT_I2C_LINE_HI(ctx.pin_sda);
+          soft_i2c_half_wait(ctx.half_us);
+          ack = soft_i2c_scl_hi(ctx);
+          if (ack)
+          {
+            SOFT_I2C_LINE_LO(ctx.pin_sda);
+            soft_i2c_half_wait(ctx.half_us);
+            SOFT_I2C_LINE_LO(ctx.pin_scl);
+            ack = soft_i2c_write_byte(ctx, 0xF0 | (i2c_addr >> 8) << 1 | 1);
+          }
+        }
+      }
+      if (!ack)
+      {
+        soft_i2c_abort(ctx);
+        return {};
+      }
+      ctx.state = read ? soft_i2c_context_t::state_t::state_read : soft_i2c_context_t::state_t::state_write;
+      return {};
+    }
+
+// ------------------------------------------------------------------------
+// Mirrors of the public functions, for the negative ports.
+
+    static inline cpp::result<void, error_t> soft_i2c_release(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.initialized)
+      {
+        ctx.initialized = false;
+        // Park the pins the same way the peripheral paths do.
+        if (ctx.pin_scl >= 0) { pinMode(ctx.pin_scl, pin_mode_t::input_pullup); }
+        if (ctx.pin_sda >= 0) { pinMode(ctx.pin_sda, pin_mode_t::input_pullup); }
+      }
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_setPins(int i2c_port, int pin_sda, int pin_scl)
+    {
+      if (!soft_i2c_valid_port(i2c_port) || pin_sda < 0 || pin_scl < 0)
+      {
+        return cpp::fail(error_t::invalid_arg);
+      }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.initialized && ctx.pin_sda == pin_sda && ctx.pin_scl == pin_scl)
+      {
+        return {};
+      }
+      soft_i2c_release(i2c_port).has_value();
+      ctx.pin_sda = pin_sda;
+      ctx.pin_scl = pin_scl;
+      return {};
+    }
+
+    static inline cpp::result<int, error_t> soft_i2c_getPinSDA(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      return soft_i2c_ctx(i2c_port).pin_sda;
+    }
+
+    static inline cpp::result<int, error_t> soft_i2c_getPinSCL(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      return soft_i2c_ctx(i2c_port).pin_scl;
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_init(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.pin_sda < 0 || ctx.pin_scl < 0) { return cpp::fail(error_t::invalid_arg); }
+      if (ctx.initialized)
+      {
+        soft_i2c_release(i2c_port).has_value();
+      }
+      soft_i2c_set_freq(ctx, 100000);  // until a transfer brings its own
+      // Both lines are released; the pullup carries them high when the bus is
+      // healthy. ( see SOFT_I2C_LINE_HI for how a line is driven afterwards )
+      pinMode(ctx.pin_sda, pin_mode_t::input_pullup);
+      pinMode(ctx.pin_scl, pin_mode_t::input_pullup);
+      ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+      ctx.initialized = true;
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_beginTransaction(int i2c_port, int i2c_addr, uint32_t freq, bool read)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.pin_sda < 0 || ctx.pin_scl < 0) { return cpp::fail(error_t::invalid_arg); }
+      if (i2c_addr < soft_i2c_7bit_addr_min || i2c_addr > soft_i2c_10bit_addr_max) { return cpp::fail(error_t::invalid_arg); }
+      SOFT_I2C_LOCK(ctx);
+      ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+      soft_i2c_set_freq(ctx, freq);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);
+      if (!soft_i2c_scl_hi(ctx))
+      { // The clock never rose: no start condition can be made on this bus.
+        soft_i2c_abort(ctx);
+        return {};
+      }
+      if (!gpio_in(ctx.pin_sda))
+      {
+        soft_i2c_recover(ctx);
+        if (!gpio_in(ctx.pin_sda))
+        { // The data line is still held; without it no start condition can be
+          // made, and the acknowledge bits would read as permanently asserted.
+          soft_i2c_abort(ctx);
+          return {};
+        }
+      }
+      SOFT_I2C_LINE_LO(ctx.pin_sda);  // start condition
+      soft_i2c_half_wait(ctx.half_us);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      return soft_i2c_send_address(ctx, i2c_addr, read);
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_restart(int i2c_port, int i2c_addr, uint32_t freq, bool read)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      if (i2c_addr < soft_i2c_7bit_addr_min || i2c_addr > soft_i2c_10bit_addr_max) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error()) { return cpp::fail(ctx.state.error()); }
+      if (ctx.state == soft_i2c_context_t::state_disconnect)
+      { // Only an open transaction can be restarted; the lock is not held here.
+        return cpp::fail(error_t::mode_mismatch);
+      }
+      soft_i2c_set_freq(ctx, freq);
+      SOFT_I2C_LINE_HI(ctx.pin_sda);  // repeated start
+      soft_i2c_half_wait(ctx.half_us);
+      if (!soft_i2c_scl_hi(ctx))
+      {
+        soft_i2c_abort(ctx);
+        return {};
+      }
+      SOFT_I2C_LINE_LO(ctx.pin_sda);
+      soft_i2c_half_wait(ctx.half_us);
+      SOFT_I2C_LINE_LO(ctx.pin_scl);
+      return soft_i2c_send_address(ctx, i2c_addr, read);
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_endTransaction(int i2c_port)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error())
+      { // The failing operation has already stopped the bus and released the lock;
+        // report its error here and clear it.
+        auto err = ctx.state.error();
+        ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+        return cpp::fail(err);
+      }
+      if (ctx.state == soft_i2c_context_t::state_disconnect) { return {}; }
+      bool stopped = soft_i2c_stop_cond(ctx);
+      ctx.state = soft_i2c_context_t::state_t::state_disconnect;
+      SOFT_I2C_UNLOCK(ctx);
+      if (!stopped) { return cpp::fail(error_t::connection_lost); }
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_writeBytes(int i2c_port, const uint8_t *data, size_t length)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error()) { return cpp::fail(ctx.state.error()); }
+      if (ctx.state != soft_i2c_context_t::state_write) { return cpp::fail(error_t::mode_mismatch); }
+      if (!length) { return {}; }
+      do
+      {
+        if (!soft_i2c_write_byte(ctx, *data++))
+        {
+          soft_i2c_abort(ctx);
+          return cpp::fail(error_t::connection_lost);
+        }
+      } while (--length);
+      return {};
+    }
+
+    static inline cpp::result<void, error_t> soft_i2c_readBytes(int i2c_port, uint8_t *readdata, size_t length, bool last_nack)
+    {
+      if (!soft_i2c_valid_port(i2c_port)) { return cpp::fail(error_t::invalid_arg); }
+      auto& ctx = soft_i2c_ctx(i2c_port);
+      if (ctx.state.has_error()) { return cpp::fail(ctx.state.error()); }
+      if (ctx.state != soft_i2c_context_t::state_read) { return cpp::fail(error_t::mode_mismatch); }
+      if (!length) { return {}; }
+      do
+      {
+        if (!soft_i2c_read_byte(ctx, readdata++, !(last_nack && length == 1)))
+        {
+          soft_i2c_abort(ctx);
+          return cpp::fail(error_t::connection_lost);
+        }
+      } while (--length);
+      return {};
+    }
+
+//----------------------------------------------------------------------------

--- a/src/lgfx/v1/platforms/soft_spi.inl
+++ b/src/lgfx/v1/platforms/soft_spi.inl
@@ -1,0 +1,168 @@
+/*----------------------------------------------------------------------------/
+  Lovyan GFX - Graphics library for embedded devices.
+
+Original Source:
+ https://github.com/lovyan03/LovyanGFX/
+
+Licence:
+ [FreeBSD](https://github.com/lovyan03/LovyanGFX/blob/master/license.txt)
+
+Author:
+ [lovyan03](https://twitter.com/lovyan03)
+
+Contributors:
+ [ciniml](https://github.com/ciniml)
+ [mongonta0716](https://github.com/mongonta0716)
+ [tobozo](https://github.com/tobozo)
+/----------------------------------------------------------------------------*/
+// SPI on plain GPIO, selected by a negative host number: host -1 is slot 0,
+// host -2 is slot 1. It reaches a bus without claiming an SPI peripheral, and
+// the convention matches the touch driver configs, where a negative host has
+// always meant bit banged GPIO.
+//
+// This file is not a header but a code fragment: a platform implementation
+// includes it inside its spi namespace, and delegates to the soft_spi_*()
+// functions at the top of each public function when the host is negative.
+// Everything here has internal linkage, so nothing beyond the negative host
+// convention becomes part of the library interface. Only the portable pin
+// functions are used, which keeps the fragment platform independent.
+#if !defined ( LGFX_INTERNAL_SOFT_SPI )
+ #error "soft_spi.inl is an implementation fragment of the spi namespace; it cannot be included directly."
+#endif
+
+//----------------------------------------------------------------------------
+
+    static constexpr int soft_spi_host_count = 2;
+
+    struct soft_spi_context_t
+    {
+      int pin_sclk = -1;
+      int pin_miso = -1;
+      int pin_mosi = -1;
+      uint32_t half_us = 0;  // 0 = unthrottled
+      uint8_t mode = 0;
+    };
+    static soft_spi_context_t soft_spi_context[soft_spi_host_count];
+
+    static inline bool soft_spi_valid_host(int spi_host) { return -soft_spi_host_count <= spi_host && spi_host < 0; }
+    static inline soft_spi_context_t& soft_spi_ctx(int spi_host) { return soft_spi_context[~spi_host]; }
+
+    static inline void soft_spi_half_wait(uint32_t half_us)
+    {
+      if (half_us) { delayMicroseconds(half_us); }
+    }
+
+    static inline void soft_spi_clock_idle(int pin_sclk, uint8_t spi_mode)
+    {
+      if (pin_sclk < 0) { return; }
+      if (spi_mode & 2) { gpio_hi(pin_sclk); } else { gpio_lo(pin_sclk); }
+    }
+
+    /// Full duplex byte shift, MSB first. read_data may be the write_data
+    /// buffer (in place), or nullptr to discard the incoming bits.
+    /// half_us throttles the clock (0 = unthrottled); the clock is left at its
+    /// idle level, which the caller has to establish before the first call
+    /// ( see soft_spi_clock_idle ).
+    static inline void soft_spi_transfer(uint8_t* read_data, const uint8_t* write_data, size_t len, const soft_spi_context_t& ctx)
+    {
+      if (!len) { return; }
+      const int pin_sclk = ctx.pin_sclk;
+      const int pin_miso = ctx.pin_miso;
+      const int pin_mosi = ctx.pin_mosi;
+      const uint32_t half_us = ctx.half_us;
+      const bool cpha = ctx.mode & 1;
+      const bool lead = !(ctx.mode & 2);  // the clock level of the leading edge
+      do
+      {
+        uint_fast8_t w = *write_data++;
+        uint_fast8_t r = 0;
+        uint_fast8_t mask = 0x80;
+        do
+        {
+          if (!cpha)
+          { // The data is set while the clock idles and sampled on the leading edge.
+            if (pin_mosi >= 0) { if (w & mask) { gpio_hi(pin_mosi); } else { gpio_lo(pin_mosi); } }
+            soft_spi_half_wait(half_us);
+            if (lead) { gpio_hi(pin_sclk); } else { gpio_lo(pin_sclk); }
+            if (pin_miso >= 0 && gpio_in(pin_miso)) { r += mask; }
+            soft_spi_half_wait(half_us);
+            if (lead) { gpio_lo(pin_sclk); } else { gpio_hi(pin_sclk); }
+          }
+          else
+          { // The data is set on the leading edge and sampled on the trailing edge.
+            if (lead) { gpio_hi(pin_sclk); } else { gpio_lo(pin_sclk); }
+            if (pin_mosi >= 0) { if (w & mask) { gpio_hi(pin_mosi); } else { gpio_lo(pin_mosi); } }
+            soft_spi_half_wait(half_us);
+            if (lead) { gpio_lo(pin_sclk); } else { gpio_hi(pin_sclk); }
+            if (pin_miso >= 0 && gpio_in(pin_miso)) { r += mask; }
+            soft_spi_half_wait(half_us);
+          }
+        } while (mask >>= 1);
+        if (read_data) { *read_data++ = r; }
+      } while (--len);
+    }
+
+// ------------------------------------------------------------------------
+// Mirrors of the public functions, for the negative hosts.
+
+    static inline cpp::result<void, error_t> soft_spi_init(int spi_host, int spi_sclk, int spi_miso, int spi_mosi)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return cpp::fail(error_t::invalid_arg); }
+      if (spi_sclk < 0) { return cpp::fail(error_t::invalid_arg); }  // the clock is not optional
+      auto& ctx = soft_spi_ctx(spi_host);
+      ctx.pin_sclk = spi_sclk;
+      ctx.pin_miso = spi_miso;
+      ctx.pin_mosi = spi_mosi;
+      ctx.mode = 0;
+      ctx.half_us = 0;
+      if (spi_sclk >= 0)
+      {
+        gpio_lo(spi_sclk); // low first, so that no HIGH pulse leaves the pin (panels without CS)
+        pinMode(spi_sclk, pin_mode_t::output);
+      }
+      if (spi_mosi >= 0) { pinMode(spi_mosi, pin_mode_t::output); }
+      if (spi_miso >= 0) { pinMode(spi_miso, pin_mode_t::input_pullup); }
+      return {};
+    }
+
+    static inline void soft_spi_release(int spi_host)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      auto& ctx = soft_spi_ctx(spi_host);
+      if (ctx.pin_sclk >= 0) { pinMode(ctx.pin_sclk, pin_mode_t::input); }
+      if (ctx.pin_miso >= 0) { pinMode(ctx.pin_miso, pin_mode_t::input); }
+      if (ctx.pin_mosi >= 0) { pinMode(ctx.pin_mosi, pin_mode_t::input); }
+      ctx = soft_spi_context_t();
+    }
+
+    static inline void soft_spi_beginTransaction(int spi_host)
+    { // Nothing to acquire; just make sure the clock rests at its idle level.
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      auto& ctx = soft_spi_ctx(spi_host);
+      soft_spi_clock_idle(ctx.pin_sclk, ctx.mode);
+    }
+
+    static inline void soft_spi_beginTransaction(int spi_host, uint32_t freq, int spi_mode)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      auto& ctx = soft_spi_ctx(spi_host);
+      ctx.mode = spi_mode & 3;
+      if (freq == 0) { freq = 100000; }  // an unset frequency falls back to a safe default
+      // Best effort, rounded up: the throttled clock must not come out above the request.
+      ctx.half_us = (freq >= 500000) ? 0 : (500000 + freq - 1) / freq;
+      soft_spi_beginTransaction(spi_host);
+    }
+
+    static inline void soft_spi_writeBytes(int spi_host, const uint8_t* data, size_t length)
+    {
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      soft_spi_transfer(nullptr, data, length, soft_spi_ctx(spi_host));
+    }
+
+    static inline void soft_spi_readBytes(int spi_host, uint8_t* data, size_t length)
+    { // Full duplex, in place: the same semantics as the peripheral paths.
+      if (!soft_spi_valid_host(spi_host)) { return; }
+      soft_spi_transfer(data, data, length, soft_spi_ctx(spi_host));
+    }
+
+//----------------------------------------------------------------------------


### PR DESCRIPTION
## What this adds

Two bus-layer extensions for the ESP32 family, plus their use in autodetect:

**Low power I2C (ESP32-C5 / C6 / P4)** — the LP I2C controller becomes reachable through the ordinary `lgfx::i2c::` API as the port right after the normal ones. Bring-up goes through the ESP-IDF master bus driver (available on ESP-IDF 5.4 or later); the per-port assumptions the code used to hard-code (port count, FIFO depth, clock source) are now derived from the SoC descriptors.

**Software I2C / SPI on negative port numbers** — a negative port/host selects a GPIO bit-banged bus: port -1 is slot 0, port -2 is slot 1. This matches the existing touch-config convention where a negative `spi_host` already means bit-banged GPIO, and negative values were never valid before, so no existing meaning changes. The implementation lives in internal fragments (`soft_i2c.inl` / `soft_spi.inl`) included inside the platform namespaces, so the only public contract is the negative number itself. `Bus_I2C` configs accept a negative port as well.

**Autodetect probing** — board probes now run over the software I2C port, so nothing on the hardware side is claimed or reconfigured until a board is confirmed; the bus is then handed over to the hardware port that the board's backlight and touch use at run time.

## Verification

- LP + software I2C: on C5 / C6 / P4 boards, a scan on each path (normal port / LP port / soft slot -1 / soft slot -2) over the same physical bus finds the same devices, and register reads return identical data.
- Software SPI: hardware loopback through a single open-drain pin and through a pin-to-pin jumper, all four SPI modes, throttled and unthrottled clocks.
- Autodetect: on the three affected chips, detection / display / backlight / touch all work, and the internal I2C scan output is byte-for-byte identical to builds without this change.
- Out-of-range slots are rejected at init.

Per-commit details are in the commit messages.
