### PR TITLE
Poll the port the transfer is on in Bus_I2C::wait() and busy()

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Bus_I2C.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_I2C.cpp
@@ -21,34 +21,11 @@ Contributors:
 #include "Bus_I2C.hpp"
 #include "../../misc/pixelcopy.hpp"
 
-#include <soc/i2c_struct.h>
-#include <type_traits>
-
 namespace lgfx
 {
  inline namespace v1
  {
 //----------------------------------------------------------------------------
-
-  // status_reg メンバーの存在を検出
-  template <typename T, typename = void>
-  struct has_status_reg : std::false_type {};
-
-  template <typename T>
-  struct has_status_reg<T, decltype(void(std::declval<T&>().status_reg))> : std::true_type {};
-
-  // bus_busy 取得
-  template <typename T>
-  static inline typename std::enable_if<has_status_reg<T>::value, bool>::type
-  i2c_dev_bus_busy(const T& dev) {
-      return dev.status_reg.bus_busy;
-  }
-
-  template <typename T>
-  static inline typename std::enable_if<!has_status_reg<T>::value, bool>::type
-  i2c_dev_bus_busy(const T& dev) {
-      return dev.sr.bus_busy;
-  }
 
   void Bus_I2C::config(const config_t& config)
   {
@@ -119,26 +96,12 @@ namespace lgfx
 
   void Bus_I2C::wait(void)
   {
-    if (_cfg.i2c_port < 0) { return; } // a software port transfers synchronously
-#if I2C_NUM_MAX > 1
-    auto dev = (_cfg.i2c_port == 0) ? &I2C0 : &I2C1;
-#else
-    auto dev = &I2C0;
-#endif
-
-    while (i2c_dev_bus_busy(*dev)) { taskYIELD(); }
+    lgfx::i2c::wait(_cfg.i2c_port);
   }
 
   bool Bus_I2C::busy(void) const
   {
-    if (_cfg.i2c_port < 0) { return false; } // a software port transfers synchronously
-#if I2C_NUM_MAX > 1
-    auto dev = (_cfg.i2c_port == 0) ? &I2C0 : &I2C1;
-#else
-    auto dev = &I2C0;
-#endif
-
-    return i2c_dev_bus_busy(*dev);
+    return lgfx::i2c::busy(_cfg.i2c_port);
   }
 
   void Bus_I2C::dc_control(bool dc)

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1398,6 +1398,15 @@ namespace lgfx
 #endif
     }
 
+    static bool getBusBusy(i2c_dev_t* dev)
+    {
+#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
+      return dev->sr.bus_busy;
+#else
+      return dev->status_reg.bus_busy;
+#endif
+    }
+
     static void i2c_set_cmd(i2c_dev_t* dev, uint8_t index, uint8_t op_code, uint8_t byte_num, bool flg_nack = false)
     {
 /*
@@ -1910,11 +1919,7 @@ namespace lgfx
       auto dev = getDev(i2c_port);
       i2c_context[i2c_port].lock();
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) ||  defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
-      if (dev->sr.bus_busy)
-#else
-      if (dev->status_reg.bus_busy)
-#endif
+      if (getBusBusy(dev))
       {
         //ESP_LOGI("LGFX", "i2c::begin wait");
         auto ms = micros();
@@ -1922,11 +1927,7 @@ namespace lgfx
         {
           taskYIELD();
         }
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
-        while (dev->sr.bus_busy && micros() - ms < 128);
-#else
-        while (dev->status_reg.bus_busy && micros() - ms < 128);
-#endif
+        while (getBusBusy(dev) && micros() - ms < 128);
       }
       i2c_context[i2c_port].save_reg(dev);
 
@@ -1996,6 +1997,21 @@ namespace lgfx
       return i2c_wait(i2c_port, true);
     }
 //*/
+    bool busy(int i2c_port)
+    {
+      if (isSoftPort(i2c_port)) { return false; } // a software port transfers synchronously
+      if (i2c_port >= I2C_NUM_MAX) { return false; }
+      return getBusBusy(getDev(i2c_port));
+    }
+
+    void wait(int i2c_port)
+    {
+      if (isSoftPort(i2c_port)) { return; } // a software port transfers synchronously
+      if (i2c_port >= I2C_NUM_MAX) { return; }
+      auto dev = getDev(i2c_port);
+      while (getBusBusy(dev)) { taskYIELD(); }
+    }
+
     cpp::result<void, error_t> writeBytes(int i2c_port, const uint8_t *data, size_t length)
     {
       if (isSoftPort(i2c_port)) { return soft_i2c_writeBytes(i2c_port, data, length); }

--- a/src/lgfx/v1/platforms/esp32/common.hpp
+++ b/src/lgfx/v1/platforms/esp32/common.hpp
@@ -355,6 +355,8 @@ protected:
     cpp::result<void, error_t> init(int i2c_port);
     cpp::result<int, error_t> getPinSDA(int i2c_port);
     cpp::result<int, error_t> getPinSCL(int i2c_port);
+    bool busy(int i2c_port);
+    void wait(int i2c_port);
 
     struct i2c_temporary_switcher_t
     {


### PR DESCRIPTION
Follow-up to a review note on #235: https://github.com/m5stack/M5GFX/pull/235#discussion_r3694331114 pointed out that `Bus_I2C::wait()` / `busy()` assume any non-negative port maps to I2C0/I2C1, which goes wrong for an LP port.

Verifying the note turned up something broader: `#if I2C_NUM_MAX > 1` never held in the first place. `I2C_NUM_MAX` is an enum constant, invisible to the preprocessor, so the condition evaluates as `0 > 1` and the I2C1 branch never compiled (confirmed empirically on ESP-IDF 4.4 and 5.x builds with a `#pragma message` probe). Both functions have therefore always polled I2C0 whatever the port: on a second hardware port — and now on an LP port — they report an idle bus while a transfer is still on the wire. Data transfers themselves were unaffected, since the i2c implementation resolves the device correctly; only the wait/busy synchronization was looking at the wrong port.

The fix routes both functions through new `i2c::wait()` / `i2c::busy()` entry points, so the port-to-device resolution lives in one place (`getDev()`, which already knows the second hardware port and the LP port). A software (negative) port reports not busy there, since its transfers are synchronous. The bus-busy bit read moves into a `getBusBusy()` accessor beside the other per-target register accessors, replacing the duplicated target lists in `beginTransaction()` and the member-detection templates Bus_I2C.cpp carried for the same purpose.

Build-verified on ESP32 (ESP-IDF 4.4, two hardware ports), ESP32-C5 (one hardware port + LP) and ESP32-P4 (two hardware ports + LP).
