### PR TITLE
Release leftover low power routing when a software I2C port is initialized

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1697,7 +1697,20 @@ namespace lgfx
 
     cpp::result<void, error_t> init(int i2c_port)
     {
-      if (isSoftPort(i2c_port)) { return soft_i2c_init(i2c_port); }
+      if (isSoftPort(i2c_port))
+      {
+#if LGFX_LP_I2C_NUM > 0 && SOC_RTCIO_PIN_COUNT > 0
+        if (soft_i2c_valid_port(i2c_port))
+        { // 低電力ポートのルーティングはリセットを跨いで残るため、前回実行が
+          // LP ポートとして使ったピンをソフトポートで取り直す場合にも返却が
+          // 必要になる。( see releaseLpPad )
+          auto& ctx = soft_i2c_ctx(i2c_port);
+          releaseLpPad((gpio_num_t)ctx.pin_sda);
+          releaseLpPad((gpio_num_t)ctx.pin_scl);
+        }
+#endif
+        return soft_i2c_init(i2c_port);
+      }
       if (i2c_port >= LGFX_I2C_PORT_NUM) { return cpp::fail(error_t::invalid_arg); }
       gpio_num_t pin_sda = i2c_context[i2c_port].pin_sda;
       gpio_num_t pin_scl = i2c_context[i2c_port].pin_scl;


### PR DESCRIPTION
A pin routed to the low power I2C keeps that routing across a reset, because it is held in the low power domain rather than by the CPU. `set_pin()` already hands such pins back before taking them for a hardware port, but the software port path did not: the bit-banged lines stayed bound to the low power peripheral and never reached the pads.

On boards whose autodetect probes the internal bus with a software port (e.g. ToughC5), this made the probe fail on every warm boot - after flashing, after a reset, and after waking from deep sleep - while a cold boot (power cycle) worked, because only a power cycle resets the routing.

This change releases the pads in `init()` for a software port as well, the same way the hardware port path does.

Verified on ToughC5: board autodetect now succeeds right after flashing and after waking from deep sleep.