### PR TITLE
Fix I2C error-stop handling: 14ms stall per failed read, noisy NACK log, LP port reset

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -2150,8 +2150,17 @@ namespace lgfx
 
           if (0 == getRxFifoCount(dev))
           {
+            uint32_t int_raw_val = dev->int_raw.val;
             i2c_stop(i2c_port);
-            ESP_LOGW("LGFX", "i2c read error : read timeout");
+            if ((int_raw_val & I2C_ACK_ERR_INT_RAW_M)
+             && !(int_raw_val & (I2C_TIME_OUT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M)))
+            { // Pure address NACK means no device is present: not a timeout, so no warning.
+              ESP_LOGV("LGFX", "i2c read error : nack");
+            }
+            else
+            {
+              ESP_LOGW("LGFX", "i2c read error : read timeout");
+            }
             res = cpp::fail(error_t::connection_lost);
             i2c_context[i2c_port].state = cpp::fail(error_t::connection_lost);
             i2c_context[i2c_port].wait_ack_stage = 0;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1149,6 +1149,13 @@ namespace lgfx
     __attribute__ ((unused))
     static void i2c_periph_reset(int i2c_num)
     {
+#if LGFX_LP_I2C_NUM > 0
+      if (isLpPort(i2c_num))
+      { // HP 用の i2c_ll_reset_register は SoC の PCR I2C 配列を範囲外参照するため LP 専用関数を使う;
+        lp_i2c_ll_reset_register(i2c_num - LGFX_HP_I2C_NUM);
+        return;
+      }
+#endif
       I2C_RCC_ATOMIC() {
         i2c_ll_reset_register(i2c_num);
         (void)__DECLARE_RCC_ATOMIC_ENV;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1498,6 +1498,7 @@ namespace lgfx
       if (i2c_context[i2c_port].state == i2c_context_t::state_disconnect) { return res; }
       auto dev = getDev(i2c_port);
       typeof(dev->int_raw) int_raw;
+      int_raw.val = dev->int_raw.val; // ACK待ちステージをスキップした場合も後段の分岐で参照されるため必ず初期化する;
       static constexpr uint32_t intmask = I2C_ACK_ERR_INT_RAW_M | I2C_END_DETECT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M;
 
       if (i2c_context[i2c_port].wait_ack_stage)
@@ -1541,12 +1542,17 @@ namespace lgfx
       if (flg_stop || res.has_error())
       {
 #if defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
-        if (res.has_error() || i2c_context[i2c_port].state == i2c_context_t::state_read || !int_raw.end_detect_int_raw)
+// エラー発生後はペリフェラルが強制停止済みの場合があり、通常のSTOPコマンド発行では完了割り込みが来ずタイムアウトまで待たされるため強制STOP側へ分岐する;
+        if (res.has_error() || i2c_context[i2c_port].state.has_error() || i2c_context[i2c_port].state == i2c_context_t::state_read || !int_raw.end_detect_int_raw)
 #else
-        if (res.has_error() || i2c_context[i2c_port].state == i2c_context_t::state_read || !int_raw.end_detect)
+        if (res.has_error() || i2c_context[i2c_port].state.has_error() || i2c_context[i2c_port].state == i2c_context_t::state_read || !int_raw.end_detect)
 #endif
         { // force stop
-          i2c_stop(i2c_port);
+          // state が既にエラーの場合はエラー検出箇所で停止済みのため再停止しない (res のエラーはこの呼び出しで検出されたもので未停止);
+          if (res.has_error() || !i2c_context[i2c_port].state.has_error())
+          {
+            i2c_stop(i2c_port);
+          }
         }
         else
         {


### PR DESCRIPTION
Fixes three problems in the ESP32 I2C error handling, found while running an I2C bus scanner that probes absent addresses with 1-byte reads.

## Symptoms

- A read from an absent address took ~20 ms instead of sub-millisecond: scanning 112 addresses took 2.4 s per sweep.
- The console was flooded with `[W][common.cpp] readBytes(): [LGFX] i2c read error : read timeout` for every probed address, which itself accounts for several ms per probe at 115200 bps.
- On chips with a low power I2C port (ESP32-C5/C6), every forced stop on the LP port reset an unrelated register.

## Fixes (one commit each)

1. **Reset a low power I2C port through its own reset register**
   `i2c_ll_reset_register(port)` indexes the PCR I2C array with the port number, but the array only holds the HP ports (`PCR.i2c[1]` on C5), so an LP port number writes out of bounds. LP ports now use `lp_i2c_ll_reset_register()`.

2. **Keep an errored I2C transaction on the forced stop path**
   In `i2c_wait()`, `int_raw` was read uninitialized whenever the ack-wait stage had been skipped (e.g. `endTransaction()` after a failed read), so the STOP-path choice was undefined. When the normal STOP command path was taken on a peripheral that had already been force-stopped by the error handling, the completion interrupt never fired and the loop waited out the full 14 ms bound. `int_raw` is now initialized, an errored context always takes the forced stop, and the redundant second hardware stop is skipped (the error handler has already issued one).

3. **Report a pure address NACK on read as NACK instead of timeout**
   An address NACK is the expected outcome when probing for devices; it is now logged at verbose level as `nack`. The timeout warning remains for genuine timeouts, and the NACK demotion only applies when neither the timeout flag nor the arbitration-lost flag is set.

With these, a failed 1-byte read probe drops from ~20 ms to sub-millisecond and the log stays quiet.

## Testing

- M5Stack Core2 (ESP32): full-bus scan sweep went from 2.4 s to well under 0.5 s; devices on the internal bus still detected correctly; no regressions in touch/RTC/PMIC traffic.
- M5Stack ToughC5 (ESP32-C5, internal bus on the LP port): scan works, and NACK probes no longer hit the out-of-bounds HP reset.
- Compile-checked for ESP32 and ESP32-C5 (HP and LP paths; the C5 branch of the chip conditionals is shared with S3/C2/C6/C61/P4/H2).
