### PR TITLE
Shared-core maintenance: BFF font RLE guard, AMOLED mirrored rotation, LEDC guard fixes

### DIFF
--- a/src/lgfx/v1/lgfx_fonts.cpp
+++ b/src/lgfx/v1/lgfx_fonts.cpp
@@ -941,7 +941,7 @@ label_nextbyte: /// 次のデータを取得する;
           if (bs->bit_pos + bpp > bs->bit_length) break;
           ret = (uint8_t)bs->read_bits(bpp);
 
-          if (bs->bit_pos != bpp && prev_v == ret)
+          if (out != 0 && prev_v == ret)
           {
             count = 0;
             state = RLE_REPEATED;

--- a/src/lgfx/v1/panel/Panel_AMOLED.cpp
+++ b/src/lgfx/v1/panel/Panel_AMOLED.cpp
@@ -45,6 +45,10 @@ namespace lgfx
                 case 1: madctl = 0x60; break;
                 case 2: madctl = 0xc0; break;
                 case 3: madctl = 0xa0; break;
+                case 4: madctl = 0xc2; break;
+                case 5: madctl = 0x62; break;
+                case 6: madctl = 0x02; break;
+                case 7: madctl = 0xa2; break;
             }
 
             startWrite();

--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -36,10 +36,11 @@ Contributors:
   #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
    #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) ledcAttach(pin_bl, freq, bits)
    #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pin_bl, duty)
-  #elif ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 0)
-   #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) { ledcSetup(pwm_channel, freq, bits); ledcAttachPin(pin_bl, pwm_channel); }
-   #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pwm_channel, duty)
   #endif
+ #endif
+ #if !defined LGFX_LEDCINIT // pre-3.x cores, including 1.x where ESP_ARDUINO_VERSION is absent
+  #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) { ledcSetup(pwm_channel, freq, bits); ledcAttachPin(pin_bl, pwm_channel); }
+  #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pwm_channel, duty)
  #endif
 
 #else // esp-idf

--- a/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
+++ b/src/lgfx/v1/platforms/esp32/Light_PWM.cpp
@@ -30,6 +30,29 @@ Contributors:
  #include <driver/ledc.h>
 #endif
 
+#if defined ( ARDUINO )
+
+ #if defined ESP_ARDUINO_VERSION // use ledc* functions shipped with arduino-esp32 core
+  #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+   #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) ledcAttach(pin_bl, freq, bits)
+   #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pin_bl, duty)
+  #elif ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 0)
+   #define LGFX_LEDCINIT(pin_bl, freq, bits, pwm_channel) { ledcSetup(pwm_channel, freq, bits); ledcAttachPin(pin_bl, pwm_channel); }
+   #define LGFX_LEDCWRITE(pin_bl, pwm_channel, duty) ledcWrite(pwm_channel, duty)
+  #endif
+ #endif
+
+#else // esp-idf
+
+  #if SOC_LEDC_SUPPORT_HS_MODE
+    #define LGFX_LEDC_SPEED_MODE LEDC_HIGH_SPEED_MODE
+  #else
+    #define LGFX_LEDC_SPEED_MODE LEDC_LOW_SPEED_MODE
+  #endif
+
+#endif
+
+
 namespace lgfx
 {
  inline namespace v1
@@ -44,59 +67,38 @@ namespace lgfx
 
 #if defined ( ARDUINO )
 
-#if defined ESP_ARDUINO_VERSION
-  #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-    #define LEDC_USE_IDF_V5 // esp32-arduino core 3.x.x uses the new ledC syntax
-  #endif
-  #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(6, 0, 0)
-    #define LEDC_USE_IDF_V6 // esp32-arduino core 6.x.x
-  #endif
-#endif
+    LGFX_LEDCINIT(_cfg.pin_bl, _cfg.freq, PWM_BITS, _cfg.pwm_channel);
 
-#if defined LEDC_USE_IDF_V5
-    ledcAttach(_cfg.pin_bl, _cfg.freq, PWM_BITS);
-    setBrightness(brightness);
-#else
-    ledcSetup(_cfg.pwm_channel, _cfg.freq, PWM_BITS);
-    ledcAttachPin(_cfg.pin_bl, _cfg.pwm_channel);
-    setBrightness(brightness);
-#endif
-#else
+#else // esp-idf
 
     static ledc_channel_config_t ledc_channel;
     {
      ledc_channel.gpio_num   = (gpio_num_t)_cfg.pin_bl;
-#if SOC_LEDC_SUPPORT_HS_MODE
-     ledc_channel.speed_mode = LEDC_HIGH_SPEED_MODE;
-#else
-     ledc_channel.speed_mode = LEDC_LOW_SPEED_MODE;
-#endif
+     ledc_channel.speed_mode = LGFX_LEDC_SPEED_MODE;
      ledc_channel.channel    = (ledc_channel_t)_cfg.pwm_channel;
-#if !defined LEDC_USE_IDF_V6  // ledc_channel_config_t.intr_type is deprecated, no need to explicitly configure interrupt, handled in the driver
-     ledc_channel.intr_type  = LEDC_INTR_DISABLE;
-#endif
      ledc_channel.timer_sel  = (ledc_timer_t)((_cfg.pwm_channel >> 1) & 3);
      ledc_channel.duty       = _cfg.invert ? (1 << PWM_BITS) : 0;
      ledc_channel.hpoint     = 0;
+ #if defined ESP_IDF_VERSION_VAL
+  // when ledc_channel_config_t.intr_type is deprecated, no need to explicitly configure interrupt, handled in the driver
+  #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+     ledc_channel.intr_type  = LEDC_INTR_DISABLE;
+  #endif
+ #endif
     };
     ledc_channel_config(&ledc_channel);
     static ledc_timer_config_t ledc_timer;
     {
-#if SOC_LEDC_SUPPORT_HS_MODE
-      ledc_timer.speed_mode = LEDC_HIGH_SPEED_MODE;     // timer mode
-#else
-      ledc_timer.speed_mode = LEDC_LOW_SPEED_MODE;
-#endif
+      ledc_timer.speed_mode = LGFX_LEDC_SPEED_MODE;     // timer mode
       ledc_timer.duty_resolution = (ledc_timer_bit_t)PWM_BITS; // resolution of PWM duty
       ledc_timer.freq_hz = _cfg.freq;                        // frequency of PWM signal
       ledc_timer.timer_num = ledc_channel.timer_sel;    // timer index
     };
     ledc_timer_config(&ledc_timer);
 
-    setBrightness(brightness);
-
 #endif
 
+    setBrightness(brightness);
     return true;
   }
 
@@ -115,17 +117,14 @@ namespace lgfx
     if (_cfg.invert) duty = (1 << PWM_BITS) - duty;
 
 #if defined ( ARDUINO )
-#if defined LEDC_USE_IDF_V5
-      ledcWrite(_cfg.pin_bl, duty);
-#else
-      ledcWrite(_cfg.pwm_channel, duty);
-#endif
-#elif SOC_LEDC_SUPPORT_HS_MODE
-      ledc_set_duty(LEDC_HIGH_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel, duty);
-      ledc_update_duty(LEDC_HIGH_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel);
-#else
-      ledc_set_duty(LEDC_LOW_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel, duty);
-      ledc_update_duty(LEDC_LOW_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel);
+
+    LGFX_LEDCWRITE(_cfg.pin_bl, _cfg.pwm_channel, duty);
+
+#else // esp-idf
+
+    ledc_set_duty(LGFX_LEDC_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel, duty);
+    ledc_update_duty(LGFX_LEDC_SPEED_MODE, (ledc_channel_t)_cfg.pwm_channel);
+
 #endif
   }
 

--- a/src/lgfx/v1/platforms/esp32/common.hpp
+++ b/src/lgfx/v1/platforms/esp32/common.hpp
@@ -30,9 +30,13 @@ Contributors:
 #include <soc/soc.h>
 #include <soc/spi_reg.h>
 #if __has_include(<soc/i2s_reg.h>)
-#include <soc/i2s_reg.h>
-#include <soc/gpio_reg.h>
-#include <soc/gpio_periph.h>
+ #include <soc/i2s_reg.h>
+#endif
+#if __has_include(<soc/gpio_reg.h>)
+ #include <soc/gpio_reg.h>
+#endif
+#if __has_include(<soc/gpio_periph.h>)
+ #include <soc/gpio_periph.h>
 #endif
 #include <soc/gpio_struct.h>
 #include <soc/gpio_sig_map.h>


### PR DESCRIPTION
## Summary

Four pending fixes for the shared graphics core, batched into one sync PR:

1. **BFF font: correct first-pixel guard in `decode_rle_bitmap`** (cherry-picked, original author credited)
   The guard for reusing the previous run value keyed off `bs->bit_pos != bpp`, which misfires on the first pixel of a glyph; it now keys off `out != 0`.

2. **Panel_AMOLED: mirrored rotation support (modes 4..7)** (cherry-picked, original author credited)
   Adds the missing MADCTL values for the four mirrored orientations.

3. **Light_PWM: consolidate LEDC conditional blocks and correct the IDF v6 `intr_type` guard**
   `ledc_channel_config_t.intr_type` carries `__attribute__((deprecated))` from ESP-IDF v6 (`components/esp_driver_ledc/include/driver/ledc.h`) — interrupts are handled inside the driver — so the field is now assigned only when building against an earlier IDF. On IDF 5.x the field is still current and the assignment is kept. The Arduino / ESP-IDF code paths are consolidated behind macros selected once at the top of the file; behavior on the success path is unchanged (Arduino 2.x keeps `ledcSetup`/`ledcAttachPin`, 3.x+ keeps `ledcAttach`).

4. **common.hpp: guard optional soc headers with `__has_include`**
   Robustness for toolchains/targets where `soc/i2s_reg.h` etc. are absent.

## Testing

- Compile-checked (native SDL build recompiles `lgfx_fonts.cpp` / `Panel_AMOLED.cpp`); the ESP32 paths are exercised by this repository's CI matrix.