### PR TITLE
Fix IDF v6 build (HSPI/VSPI aliases) and extend the CI matrix

### DIFF
--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.board }} (${{ matrix.esp32_version }})
@@ -43,6 +48,10 @@ jobs:
             board_manager_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
           - board: esp32:esp32:esp32c3
             esp32_version: 3.1.1
+            board_manager_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          # ESP32-C5 (v3.3+ only)
+          - board: esp32:esp32:esp32c5
+            esp32_version: 3.3.11
             board_manager_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
           # ESP32-C6 (v3 only)
           - board: esp32:esp32:esp32c6

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.target }} (IDF ${{ matrix.idf_version }})
@@ -27,6 +32,8 @@ jobs:
             idf_version: "5.3"
           - target: esp32
             idf_version: "5.1.6"
+          - target: esp32
+            idf_version: "6.0.2"
           # ESP32-S3
           - target: esp32s3
             idf_version: "5.3"
@@ -37,9 +44,14 @@ jobs:
             idf_version: "5.3"
           - target: esp32c3
             idf_version: "5.1.6"
+          # ESP32-C5 (IDF 5.5+ only)
+          - target: esp32c5
+            idf_version: "5.5.2"
           # ESP32-C6 (IDF 5.3+ only)
           - target: esp32c6
             idf_version: "5.3"
+          - target: esp32c6
+            idf_version: "5.5.2"
           # ESP32-H2
           - target: esp32h2
             idf_version: "5.3"

--- a/src/M5AtomDisplay.h
+++ b/src/M5AtomDisplay.h
@@ -138,7 +138,7 @@ public:
     int spi_sclk = GPIO_NUM_7;
 
 #elif !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
- #define M5GFX_SPI_HOST VSPI_HOST
+ #define M5GFX_SPI_HOST SPI3_HOST
 
     int i2c_port = 1;
     int i2c_sda  = GPIO_NUM_25;

--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -1153,7 +1153,7 @@ namespace m5gfx
 
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
 
-    bus_cfg.spi_host = VSPI_HOST;
+    bus_cfg.spi_host = SPI3_HOST;
     bus_cfg.dma_channel = 1;
 
     std::uint32_t id;
@@ -1180,7 +1180,7 @@ namespace m5gfx
           board = board_t::board_M5StickCPlus;
           ESP_LOGI(LIBRARY_NAME, "[Autodetect] M5StickCPlus");
           bus_spi->release();
-          bus_cfg.spi_host = HSPI_HOST;
+          bus_cfg.spi_host = SPI2_HOST;
           bus_cfg.freq_write = 40000000;
           bus_cfg.freq_read  = 15000000;
           bus_spi->config(bus_cfg);
@@ -1195,7 +1195,7 @@ namespace m5gfx
           board = board_t::board_M5StickC;
           ESP_LOGI(LIBRARY_NAME, "[Autodetect] M5StickC");
           bus_spi->release();
-          bus_cfg.spi_host = HSPI_HOST;
+          bus_cfg.spi_host = SPI2_HOST;
           bus_cfg.freq_write = 27000000;
           bus_cfg.freq_read  = 14000000;
           bus_spi->config(bus_cfg);
@@ -1280,7 +1280,7 @@ namespace m5gfx
           board = board_t::board_M5StickCPlus2;
           ESP_LOGI(LIBRARY_NAME, "[Autodetect] M5StickCPlus2");
           bus_spi->release();
-          bus_cfg.spi_host = HSPI_HOST;
+          bus_cfg.spi_host = SPI2_HOST;
           bus_cfg.freq_write = 40000000;
           bus_cfg.freq_read  = 15000000;
           bus_spi->config(bus_cfg);
@@ -1350,7 +1350,7 @@ namespace m5gfx
               board = board_t::board_M5Station;
 
               bus_spi->release();
-              bus_cfg.spi_host = HSPI_HOST;
+              bus_cfg.spi_host = SPI2_HOST;
               bus_cfg.freq_write = 40000000;
               bus_cfg.freq_read  = 15000000;
               bus_spi->config(bus_cfg);

--- a/src/M5ModuleDisplay.h
+++ b/src/M5ModuleDisplay.h
@@ -149,7 +149,7 @@ public:
     int spi_sclk = GPIO_NUM_36;
 
 #elif !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
- #define M5GFX_SPI_HOST VSPI_HOST
+ #define M5GFX_SPI_HOST SPI3_HOST
 
     int i2c_port = 1;
     int i2c_sda  = GPIO_NUM_21;


### PR DESCRIPTION
## Summary

Two related changes, validated together on a fork run of the extended matrix:

1. **Use `SPI2_HOST`/`SPI3_HOST` instead of the removed `HSPI_HOST`/`VSPI_HOST` aliases.**
   ESP-IDF v6 drops the ESP32-classic aliases, which broke the board autodetect path (`M5GFX.cpp`) and the Atom/Module display headers when building against it. `SPI2_HOST`/`SPI3_HOST` are the canonical names since IDF v4, so every Arduino core and IDF version already covered by CI keeps building (the shared `lgfx` layer was unaffected — it guards these aliases with `#if defined`).

2. **CI matrix additions:**
   - IDF: `esp32c5 @ 5.5.2` (a supported product chip that had no IDF-side coverage), `esp32c6 @ 5.5.2` (compiles the low-power peripheral paths that 5.3 leaves out), and `esp32 @ 6.0.2` (surfaces next-major deprecations early — it is what caught the alias removal above).
   - Arduino: `esp32c5 @ arduino-esp32 3.3.11` (C5 support landed in the 3.3 series).
   - Both workflows cancel superseded runs of the same branch or pull request (group keyed by event name and PR number, so runs from different forks cannot cancel each other).

## Testing

- Fork run of the full extended matrix: all IDF jobs green (including `esp32 @ 6.0.2`, `esp32c5 @ 5.5.2`, `esp32c6 @ 5.5.2`) and all Arduino jobs green (including `esp32c5 @ 3.3.11`).
- Job-count impact: +3 IDF jobs and +1 Arduino job, each ~2 min in the containerized lanes.