### PR TITLE
Fix M5Tab5 black screen after a warm reset (wait for the touch controller response)

### DIFF
--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -2940,12 +2940,26 @@ The usage of each pin is as follows.
             bool hit_st7121 = false;
             bool hit_st7123 = false;
             bool read_st_touch_fw = false;
-            for (int i = 0; i < 3; ++i) {
+            bool found_gt911 = false;
+            // ST71xx のタッチコントローラは、スキャン動作中にリセットされた場合、
+            // 応答可能になるまで数十 ms を要する (実測: 稼働中からのソフトリセット後
+            // およそ 50ms)。待ちを打ち切ると ST パネルの判別に失敗して表示が出ない
+            // (ST7121/ST7123 は lane 速度が異なり DSI ID では安全に区別できない) ため、
+            // ST touch の既知 FW 版数 (1/3) を認識するか GT911 (ILI9881C 個体) が
+            // ACK するまで待つ。
+            int last_logged_fw = -1;
+            for (int i = 0; i < 60; ++i) {
               uint8_t fw_version = 0;
               uint8_t fw_reg[2] = { 0, 0 };
               if (lgfx::i2c::transactionWriteRead(probe_i2c_port, Touch_ST7123::default_addr, fw_reg, sizeof(fw_reg), &fw_version, 1, 100000).has_value()) {
                 read_st_touch_fw = true;
-                ESP_LOGI(LIBRARY_NAME, "M5Tab5 ST touch FW version %02x", fw_version);
+                if (fw_version != last_logged_fw) {  // 未知値のリトライ継続で同じログを繰り返さない
+                  last_logged_fw = fw_version;
+                  ESP_LOGI(LIBRARY_NAME, "M5Tab5 ST touch FW version %02x", fw_version);
+                  if (fw_version != 1 && fw_version != 3) {
+                    ESP_LOGW(LIBRARY_NAME, "M5Tab5 unknown ST touch FW version %02x", fw_version);
+                  }
+                }
                 if (fw_version == 1) {
                   hit_st7121 = true;
                   break;
@@ -2954,11 +2968,18 @@ The usage of each pin is as follows.
                   hit_st7123 = true;
                   break;
                 }
-                ESP_LOGW(LIBRARY_NAME, "M5Tab5 unknown ST touch FW version %02x", fw_version);
+              } else {
+                // GT911 はアドレス ACK の確認のみ (実読すると内部ポインタを進めてしまう)
+                if (lgfx::i2c::beginTransaction(probe_i2c_port, Touch_GT911::default_addr_1, 100000, false).has_value()
+                 && lgfx::i2c::endTransaction(probe_i2c_port).has_value()) {
+                  found_gt911 = true;
+                  ESP_LOGI(LIBRARY_NAME, "M5Tab5 GT911 touch detected");
+                  break;
+                }
               }
               lgfx::delay(10);
             }
-            if (!read_st_touch_fw) {
+            if (!read_st_touch_fw && !found_gt911) {
               ESP_LOGW(LIBRARY_NAME, "M5Tab5 ST touch FW version read failed");
             }
 


### PR DESCRIPTION
## Problem

On M5Tab5 units with the ST7121/ST7123 panel, the screen stays black after a warm reset from a running state — e.g. `esp_restart()`, or the reset issued when a serial monitor connects to the USB-Serial-JTAG port. Cold boots and esptool-style resets are unaffected, and the failure typically alternates (every other reboot works), which makes it look intermittent.

## Cause

The ST71xx touch controller needs several tens of milliseconds (measured: ~50 ms) to respond on I2C again when it is reset in the middle of scan operation. The autodetect probe that reads the touch firmware version to distinguish ST7121/ST7123 gave up after 3 attempts x 10 ms, so the panel type could not be determined and autodetect bailed out with `M5Tab5 display panel was not detected`. The alternation happens because a failed boot never starts the touch controller, so on the next boot it responds immediately.

## Fix

Poll until a recognized ST71xx firmware version is read or the GT911 (ILI9881C variant) ACKs, up to roughly 600 ms. The loop exits as soon as either controller responds, so the boot time is unchanged on both variants. The GT911 check is an address-ACK-only transaction to avoid disturbing its internal register pointer.

If no touch controller ever responds, the behavior falls back to the previous path: the ILI9881C variant is still identified by its DSI ID, while the ST variants still require the touch FW version because their DSI timings (900 vs 1040 Mbps lanes) cannot be distinguished safely from the DSI ID alone.

## Verification (real hardware)

- ST7123 unit, ESP-IDF 5.5.3 and 6.0.2: 5x consecutive `esp_restart()` from a running display plus a USB-JTAG reset — 6/6 boots initialize and display correctly (previously alternating black).
- ILI9881C + GT911 unit, ESP-IDF 5.5.3: same sequence, 6/6 boots OK; the GT911 ACKs on the first attempt, so no boot-time delay is added.
