### PR TITLE
AtomS3R: re-probe the panel ID at low clock speed before giving up

### DIFF
--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -2760,6 +2760,24 @@ The usage of each pin is as follows.
         bool is_st7735 = ((id & 0xFFFF) == 0x7683 || (id & 0xFFFF) == 0x897C);
         bool is_gc9107 = (id & 0xFFFFFF) == 0x079100;
 //      ESP_LOGI(LIBRARY_NAME, "[Autodetect] panel_id: 0x%08x", id);
+        if (!is_st7735 && !is_gc9107)
+        { // Some GC9107 batches return a valid ID only at low clock rates;
+          // re-probe slowly before giving up.
+          // (ST7735 does not answer at this rate, but a healthy one has
+          //  already been caught by the first probe above.)
+          bus_spi->release();
+          bus_cfg.freq_write = 100000;
+          bus_cfg.freq_read  = 100000;
+          bus_spi->config(bus_cfg);
+          bus_spi->init();
+          id = _read_panel_id(bus_spi, GPIO_NUM_14);
+          // restore the probe speed in bus_cfg: later board probes reuse it
+          // without setting the frequency themselves.
+          bus_cfg.freq_write = 8000000;
+          bus_cfg.freq_read  = 8000000;
+          is_st7735 = ((id & 0xFFFF) == 0x7683 || (id & 0xFFFF) == 0x897C);
+          is_gc9107 = (id & 0xFFFFFF) == 0x079100;
+        }
         if (is_st7735 || is_gc9107)
         {
           board = board_t::board_M5AtomS3R;


### PR DESCRIPTION
Fixes #222.

## Problem

Some AtomS3R GC9107 panel batches return a valid ID over the RDDID command only at low clock rates. At the probe speed (8 MHz) the readout is garbage, so autodetect matched neither known panel ID and silently bound no display — the unit appeared dead (black screen, backlight on) under every M5GFX-based firmware.

## Fix

When the first ID probe matches neither known ID, re-probe once at 100 kHz before giving up. The retry only runs after a failed first probe, so healthy units keep the exact same fast path. 100 kHz was chosen because it is the regime the reporter verified on an affected unit (bit-banged readback at ~100 kHz returns the exact expected `0x079100`, and even there the readback is timing-marginal).

Defaulting to GC9107 on an unknown ID was rejected as an alternative because it would misidentify ST7735 variants.

## Verification (real hardware, one GC9107 unit and one ST7735 unit)

- Healthy GC9107 and ST7735 units: detected via the first 8 MHz probe, timing unchanged (no regression; the retry stays dormant).
- Forced-retry test (first probe result artificially discarded in a local build): the 100 kHz re-probe returns the correct `0x079100` on the GC9107 unit and the panel initializes normally.
- The ST7735 does not answer the RDDID readout at low clock rates at all (verified: `0xFFFFFFFF` at 1 MHz and below, correct at 8 MHz), so the slow retry cannot misidentify an ST7735; a healthy one has already been caught by the first probe.

The affected panel batch itself was not available for testing. The issue reporter offered to run further tests on their unit; verification from this branch (or after merge) would be welcome.
