### PR TITLE
Add M5Tab5X display support

### DIFF
--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -2921,7 +2921,7 @@ The usage of each pin is as follows.
 
     if (pkg_ver == 0) // pkg_ver == EFUSE_RD_CHIP_VER_PKG_
     {
-      if (board == 0 || board == board_t::board_M5Tab5)
+      if (board == 0 || board == board_t::board_M5Tab5 || board == board_t::board_M5Tab5X)
       {
         // SDA = GPIO_NUM_31
         // SCL = GPIO_NUM_32
@@ -2934,8 +2934,10 @@ The usage of each pin is as follows.
         id = lgfx::i2c::readRegister8(probe_i2c_port, pi4io1_i2c_addr, 0x01).has_value()
           && lgfx::i2c::readRegister8(probe_i2c_port, pi4io2_i2c_addr, 0x01).has_value();
         if (id != 0) {
-          board = board_t::board_M5Tab5;
-          ESP_LOGI(LIBRARY_NAME, "[Autodetect] board_M5Tab5");
+          if (board == 0)
+            board = board_t::board_M5Tab5;
+          ESP_LOGI(LIBRARY_NAME, "[Autodetect] %s",
+                   board == board_t::board_M5Tab5X ? "board_M5Tab5X" : "board_M5Tab5");
 
           static constexpr const uint8_t reg_data_io1_1[] = {
             0x03, 0b01111111, 0,   // PI4IO_REG_IO_DIR
@@ -3717,6 +3719,7 @@ init_clear:
     case board_M5VAMeter:      title = "M5VAMeter";      break;
     case board_M5StampPLC:     title = "M5StampPLC";     break;
     case board_M5Tab5:         title = "M5Tab5";         break;
+    case board_M5Tab5X:        title = "M5Tab5X";        break;
     case board_M5UnitPoEP4:    title = "M5UnitPoEP4";    break;
     case board_ArduinoNessoN1: title = "ArduinoNessoN1"; break;
     default:                   title = "M5GFX";          break;
@@ -3809,6 +3812,7 @@ init_clear:
       break;
 
     case board_M5Tab5:
+    case board_M5Tab5X:
       w = 720;
       h = 1280;
       break;

--- a/src/lgfx/boards.hpp
+++ b/src/lgfx/boards.hpp
@@ -43,6 +43,7 @@ namespace lgfx // This should not be changed to "m5gfx"
     , board_M5ChainCaptain = 32
     , board_M5ToughC5 = 33
     , board_M5PaperDIY = 34
+    , board_M5Tab5X = 35
 
 /// non display boards
     , board_M5AtomLite = 128

--- a/src/lgfx/v1/platforms/esp32p4/Bus_DSI.cpp
+++ b/src/lgfx/v1/platforms/esp32p4/Bus_DSI.cpp
@@ -31,10 +31,9 @@ namespace lgfx
     if (_mipi_dsi_bus) {
       return true;
     }
-    esp_lcd_dsi_bus_config_t bus_config;
+    esp_lcd_dsi_bus_config_t bus_config = {};
     bus_config.bus_id = _cfg.bus_id;
     bus_config.num_data_lanes = _cfg.lane_num;
-    bus_config.phy_clk_src = static_cast<typeof(bus_config.phy_clk_src)>(MIPI_DSI_PHY_CLK_SRC_DEFAULT);
     bus_config.lane_bit_rate_mbps = _cfg.lane_mbps;
 
     esp_ldo_channel_config_t ldo_cfg;

--- a/src/picture_frame/picture_frame.h
+++ b/src/picture_frame/picture_frame.h
@@ -42,7 +42,8 @@ namespace m5gfx
     case board_M5StickCPlus:    return &picture_frame_M5StickCPlus;
     case board_M5StickCPlus2:   return &picture_frame_M5StickCPlus2;
     case board_M5Dial:          return &picture_frame_M5Dial;
-    case board_M5Tab5:          return &picture_frame_M5Tab5;
+    case board_M5Tab5:
+    case board_M5Tab5X:         return &picture_frame_M5Tab5;
     default: return nullptr;
     }
   }


### PR DESCRIPTION
Tab5X upgrades the ESP32-P4 silicon revision used by Tab5.