### PR TITLE
Survive I2C slaves that stretch the clock

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -1654,6 +1654,11 @@ namespace lgfx
       for (auto &bup : backup_pins) { bup.restore(); }
     }
 
+    /// Minimum time a transfer may stall (clock stretching or a wedged bus)
+    /// before it is given up on; 25ms covers the SMBus Tlow:sext ceiling.
+    /// NACK handling does not depend on this limit.
+    static constexpr uint32_t i2c_stall_limit_us = 25000;
+
     static cpp::result<void, error_t> i2c_wait(int i2c_port, bool flg_stop = false)
     {
       if (flg_stop == false && i2c_context[i2c_port].state.has_error()) { return cpp::fail(i2c_context[i2c_port].state.error()); }
@@ -1662,7 +1667,7 @@ namespace lgfx
       auto dev = getDev(i2c_port);
       typeof(dev->int_raw) int_raw;
       int_raw.val = dev->int_raw.val; // ACK待ちステージをスキップした場合も後段の分岐で参照されるため必ず初期化する;
-      static constexpr uint32_t intmask = I2C_ACK_ERR_INT_RAW_M | I2C_END_DETECT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M;
+      static constexpr uint32_t intmask = I2C_ACK_ERR_INT_RAW_M | I2C_TIME_OUT_INT_RAW_M | I2C_END_DETECT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M;
 
       if (i2c_context[i2c_port].wait_ack_stage)
       {
@@ -1676,7 +1681,7 @@ namespace lgfx
 #else
           uint32_t us_limit = (dev->scl_high_period.period + dev->scl_low_period.period + 16 ) * (1 + dev->status_reg.tx_fifo_cnt);
 #endif
-          us_limit += 512 << i2c_context[i2c_port].wait_ack_stage;
+          us_limit += i2c_stall_limit_us;
 
           do
           {
@@ -1688,6 +1693,13 @@ namespace lgfx
         int_raw.val = dev->int_raw.val;
 
         dev->int_clr.val = int_raw.val;
+        // A timeout or lost arbitration is fatal even when END is also set.
+        if (int_raw.val & (I2C_TIME_OUT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M))
+        {
+          res = cpp::fail(error_t::connection_lost);
+          i2c_context[i2c_port].state = cpp::fail(error_t::connection_lost);
+        }
+        else
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
         if (!int_raw.end_detect || int_raw.ack_err)
 #elif defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
@@ -1721,13 +1733,27 @@ namespace lgfx
         {
           i2c_set_cmd(dev, 0, i2c_cmd_stop, 0);
           i2c_set_cmd(dev, 1, i2c_cmd_end, 0);
-          static constexpr uint32_t intmask_ = I2C_ACK_ERR_INT_RAW_M | I2C_TIME_OUT_INT_RAW_M | I2C_END_DETECT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M | I2C_TRANS_COMPLETE_INT_RAW_M;
+          // Wake only on events that end the STOP; a NACK is evaluated after it completes.
+          static constexpr uint32_t intmask_ = I2C_TIME_OUT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M | I2C_TRANS_COMPLETE_INT_RAW_M;
           updateDev(dev);
-          dev->int_clr.val = intmask_;
+          dev->int_clr.val = intmask_ | I2C_ACK_ERR_INT_RAW_M | I2C_END_DETECT_INT_RAW_M;
           dev->ctr.trans_start = 1;
           uint32_t ms = lgfx::millis();
           taskYIELD();
-          while (!(dev->int_raw.val & intmask_) && ((millis() - ms) < 14));
+          while (!(dev->int_raw.val & intmask_) && ((millis() - ms) < (i2c_stall_limit_us / 1000))) { taskYIELD(); }
+          // A STOP that did not complete leaves the bus in an unknown state:
+          // recover it and refuse further use of this transaction.
+          {
+            uint32_t stop_raw = dev->int_raw.val;
+            if (res.has_value()
+             && ((stop_raw & (I2C_TIME_OUT_INT_RAW_M | I2C_ARBITRATION_LOST_INT_RAW_M))
+              || !(stop_raw & I2C_TRANS_COMPLETE_INT_RAW_M)))
+            {
+              res = cpp::fail(error_t::connection_lost);
+              i2c_context[i2c_port].state = cpp::fail(error_t::connection_lost);
+              i2c_stop(i2c_port);
+            }
+          }
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
           if (res.has_value() && dev->int_raw.ack_err)
 #elif defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
@@ -1735,8 +1761,9 @@ namespace lgfx
 #else
           if (res.has_value() && dev->int_raw.nack)
 #endif
-          {
+          { // The STOP completed but a byte went unacknowledged.
             res = cpp::fail(error_t::connection_lost);
+            i2c_context[i2c_port].state = cpp::fail(error_t::connection_lost);
           }
           //ESP_LOGI("LGFX", "I2C stop");
         }
@@ -2143,11 +2170,14 @@ namespace lgfx
       dev->ctr.fsm_rst = 1;
 #endif
 
+// SCL-low (clock stretch) watchdog. 2^21 source clocks stays past
+// i2c_stall_limit_us on every supported source; the ESP32 register below is at
+// its ceiling, about 13ms.
 #if defined ( CONFIG_IDF_TARGET_ESP32C3 )
-      dev->timeout.time_out_value = 31;
+      dev->timeout.time_out_value = 21;
       dev->timeout.time_out_en = 1;
 #elif defined ( CONFIG_IDF_TARGET_ESP32C2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 )
-      dev->to.time_out_value = 31;
+      dev->to.time_out_value = 21;
       dev->to.time_out_en = 1;
 #else
       dev->timeout.tout = 0xFFFFF; // max 13ms
@@ -2310,7 +2340,7 @@ namespace lgfx
           do
           {
             taskYIELD();
-          } while ((len>>1) >= getRxFifoCount(dev) && !(dev->int_raw.val & intmask) && ((lgfx::micros() - us) <= us_limit + 1024));
+          } while ((len>>1) >= getRxFifoCount(dev) && !(dev->int_raw.val & intmask) && ((lgfx::micros() - us) <= us_limit + i2c_stall_limit_us));
 
           if (0 == getRxFifoCount(dev))
           {

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -2296,6 +2296,7 @@ namespace lgfx
         updateDev(dev);
         dev->int_clr.val = intmask;
         dev->ctr.trans_start = 1;
+        i2c_context[i2c_port].wait_ack_stage = 2;
 
         uint32_t us = lgfx::micros();
         taskYIELD();

--- a/src/lgfx/v1/platforms/soft_i2c.inl
+++ b/src/lgfx/v1/platforms/soft_i2c.inl
@@ -165,7 +165,7 @@ Contributors:
       {
         SOFT_I2C_YIELD();
         if (gpio_in(ctx.pin_scl)) { return true; }
-      } while ((micros() - us) < 13000); // the same order as a peripheral timeout
+      } while ((micros() - us) < 25000); // the same stall allowance as the peripheral ports
       return false;
     }
 


### PR DESCRIPTION
This pair of commits makes the ESP32 hardware I2C master survive slaves that stretch the clock, from the microsecond-scale stretches a slave needs to prepare its response up to the tens of milliseconds allowed by SMBus.

## The race (first commit)

`readBytes` splits a transfer at the RX FIFO boundary, but unlike `writeBytes` it never recorded a wait stage for the command it started. Nothing waited for or cleared the command's END interrupt, so the next chunk (or `endTransaction` / `restart`) could reprogram the command registers while the peripheral was still finishing the previous chunk, and a stale END from chunk N defeated the FIFO poll of chunk N+1.

This is not a theoretical window. Measured with a host reading 31 to 128 bytes from a slave (an ESP32-C61 in slave mode) that stretches the clock while preparing its response:

| stretch injected | before | after |
|---|---|---|
| none (only the slave's natural stretching) | chunked reads (33+ bytes) failed intermittently | all lengths pass |
| 500 µs at the 32-byte chunk boundary | worse, with corrupted reads | all lengths pass |

The fix records the same data-transfer wait stage `writeBytes` uses, so every path that follows waits for and consumes the command completion.

## The stall limits (second commit)

The software wait limits gave a stalled transfer roughly 1-2 ms before declaring `connection_lost`: the FIFO poll allowed `us_limit + 1024` µs and the END wait allowed `512 << stage`. A slave legally holding SCL longer than that had its transfer killed. The commit raises both limits to a shared constant sized for the SMBus Tlow:sext ceiling (25 ms) and makes the waits, the watchdog, and the error reporting agree on what a stall means:

- `i2c_wait` also wakes on TIME_OUT, and treats TIME_OUT or a lost arbitration as fatal even when END is set alongside, matching the SDK's event priority.
- The STOP wait wakes only on events that actually end a STOP and requires TRANS_COMPLETE: a watchdog bite, a lost arbitration, or the limit expiring with no interrupt at all used to return success from `endTransaction`. A failed STOP now forces a bus recovery and poisons the context state so the split API refuses to continue the dead transaction; the next `beginTransaction` starts from a recovered bus.
- The exponent-encoded SCL-low watchdog moves from 2^31 source clocks (almost a minute, which made it meaningless) to 2^21, past the software allowance on every supported source clock including the 48 MHz XTAL the ESP32-C5 can run, so the software limit is the authority on tolerated stretching.
- The soft I2C SCL-high wait adopts the same 25 ms allowance.

Measured stretch tolerance after the change:

| target | tolerated stretch | bounded by |
|---|---|---|
| ESP32 | ≈13 ms (10 ms passes, 15 ms reported) | SCL-low watchdog register ceiling (`0xFFFFF`) |
| ESP32-S3 | 25 ms (15 ms passes, 30 ms reported) | the software limit |

In both cases the failure is reported as `connection_lost` and the bus recovers cleanly on the next transaction.

## NACK handling is unaffected

Probing an absent device does not lean on these limits, so it stays fast. Measured on an ESP32 (Core BASIC): an address NACK raises no error interrupt at all — the command sequence still runs to its END interrupt, and the error only surfaces in the `ack_err` evaluation after STOP, which is the existing detection path. Absent-address probe times are 103-111 µs both before and after this change (the write path that ends in the STOP evaluation included), and present-device transactions are unchanged.

Verified on ESP32 and ESP32-S3 hosts against a clock-stretching slave, sweeping 31/32/33/64/128-byte reads at 400/100/50 kHz with pattern verification and stretch injections from 0 to 30 ms.
