### PR TITLE
Bus_SPI: restore SPI_USER_REG before releasing the bus lock

### DIFF
--- a/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
+++ b/src/lgfx/v1/platforms/esp32/Bus_SPI.cpp
@@ -566,10 +566,10 @@ namespace lgfx
 #if defined (LGFX_SPI_CLOCK_TAKEOVER)
     if (_cfg.use_lock) { spi_clock_restore(this, _cfg.spi_host); }
 #endif
-    if (_cfg.use_lock) spi::endTransaction(_cfg.spi_host);
 #if defined (ARDUINO) // Arduino ESP32
     *_spi_user_reg = SPI_USR_MOSI | SPI_USR_MISO | SPI_DOUTDIN; // for other SPI device (e.g. SD card)
 #endif
+    if (_cfg.use_lock) spi::endTransaction(_cfg.spi_host);
   }
 
   void Bus_SPI::wait(void)


### PR DESCRIPTION
## What this changes

`Bus_SPI::endTransaction()` restored `SPI_USER_REG` to its idle value (`USR_MOSI | USR_MISO | DOUTDIN`) *after* `spi::endTransaction()` had released the bus mutex. This moves the restore above the unlock. One line, no behaviour change for a bus that is not shared.

## Why

Another task blocked on the mutex can already have its own transaction configured and running when the late write lands. The write clears `ck_out_edge`, so a mode 1/2 device sharing the bus gets its next chunk on the wrong clock edge.

Measured on ESP32-S3 (SPI panel at 40 MHz with DMA + a second task holding `SPI.beginTransaction(SPI_MODE2)` and checking `ck_out_edge` after each 64-byte chunk):

| build | second task placement | duration | chunks | `ck_out_edge` lost |
|---|---|---|---|---|
| before | other core | 60 s | 719k | 0 |
| before | same core / same priority as the panel task | 180 s | 723k | 5 |
| after | same core / same priority | 180 s | 723k | 0 |

The window is only hit when the panel task is preempted between the unlock and the write (same core, tick round-robin). Mode-0 devices are unaffected either way (the late write equals what they program themselves) — a 5-minute SD card soak on the shared bus showed 0 errors before and after.
