### PR TITLE
Link the Arduino component automatically when built as an ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,41 @@ else()
     set(COMPONENT_REQUIRES nvs_flash efuse)
 endif()
 
-### If you use arduino-esp32 components, please activate next comment line.
-# list(APPEND COMPONENT_REQUIRES arduino-esp32)
 
 
 message(STATUS "M5GFX use components = ${COMPONENT_REQUIRES}")
 
 register_component()
+
+# Arduino as an ESP-IDF component: arduino-esp32 publishes -DARDUINO... as PUBLIC compile options, so
+# they only reach components that link against it, while the public headers of this library change
+# class layout with ARDUINO. Link the Arduino component publicly whenever it is part of the build so
+# this library is compiled in the same mode as the application. Only components already selected
+# for the build are considered; a build without Arduino is unaffected.
+#   M5GFX_ARDUINO_COMPONENT=<name>  use a differently named Arduino component
+#   M5GFX_ARDUINO_COMPONENT=OFF     disable the automatic dependency
+set(_m5gfx_arduino_candidates arduino arduino-esp32 espressif__arduino-esp32)
+set(_m5gfx_arduino_enabled ON)
+if(DEFINED M5GFX_ARDUINO_COMPONENT AND NOT "${M5GFX_ARDUINO_COMPONENT}" STREQUAL "")
+    if(M5GFX_ARDUINO_COMPONENT)
+        set(_m5gfx_arduino_candidates ${M5GFX_ARDUINO_COMPONENT})
+    else()
+        set(_m5gfx_arduino_enabled OFF)
+    endif()
+endif()
+if(_m5gfx_arduino_enabled)
+    idf_build_get_property(_m5gfx_arduino_build_components BUILD_COMPONENTS)
+    set(_m5gfx_arduino_hits)
+    foreach(_m5gfx_arduino_name ${_m5gfx_arduino_candidates})
+        if(_m5gfx_arduino_name IN_LIST _m5gfx_arduino_build_components)
+            list(APPEND _m5gfx_arduino_hits ${_m5gfx_arduino_name})
+        endif()
+    endforeach()
+    list(LENGTH _m5gfx_arduino_hits _m5gfx_arduino_count)
+    if(_m5gfx_arduino_count GREATER 1)
+        message(FATAL_ERROR "M5GFX: several Arduino components are in the build (${_m5gfx_arduino_hits}). Set M5GFX_ARDUINO_COMPONENT to the one to use.")
+    elseif(_m5gfx_arduino_count EQUAL 1)
+        idf_component_get_property(_m5gfx_arduino_lib ${_m5gfx_arduino_hits} COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${_m5gfx_arduino_lib})
+    endif()
+endif()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Supported framework
 - Arduino for ESP32
 
 
+
 Supported device  
 ----------------
 - M5Stack ( Basic / Gray / GO / Fire )
@@ -37,6 +38,16 @@ Supported device
 - UnitGLASS2
 - [AtomDisplay](docs/ATOMDisplay.md) / ModuleDisplay
 
+
+Notes
+----------------
+### Arduino as an ESP-IDF component
+When arduino-esp32 is used as an ESP-IDF component together with this library, the library links
+the Arduino component automatically (it looks for a component named `arduino`, `arduino-esp32` or
+`espressif__arduino-esp32` in the build) so that it is compiled with the same `ARDUINO` definitions
+as the application. Without that, the application and the library would see different layouts of the
+same classes. Set `M5GFX_ARDUINO_COMPONENT=<name>` (CMake cache variable) if your Arduino component
+has another name, or `M5GFX_ARDUINO_COMPONENT=OFF` to disable this.
 
 License
 ----------------


### PR DESCRIPTION
## Problem

When arduino-esp32 is used as an ESP-IDF component, its `-DARDUINO=...` definitions are exported as `PUBLIC` compile options of the Arduino component, so they only reach components that link against it — the application (`main`) does, this library did not. The public headers of this library change class layout with `ARDUINO` (for example the base class derives from `Print` only under `ARDUINO`), so the application read the same objects with a layout different from the one the library was compiled with: `getPanel()` returned null and the first drawing call faulted.

The `CMakeLists.txt` already carried the fix as a commented-out line (`list(APPEND COMPONENT_REQUIRES arduino-esp32)`), but a user of the component registry cannot enable it.

## Change

After `register_component()`, look for an Arduino component among the components selected for the build (`arduino`, `arduino-esp32` or `espressif__arduino-esp32`) and link it `PUBLIC`, so this library is compiled with the same definitions as the application. Only `BUILD_COMPONENTS` is consulted: a build that does not contain Arduino, or excludes it with `COMPONENTS` / `EXCLUDE_COMPONENTS`, is unaffected. Only APIs available since ESP-IDF 4.x are used. This is the same pattern arduino-esp32 itself uses for its optional dependencies (`maybe_add_component`).

- `M5GFX_ARDUINO_COMPONENT=<name>` selects a differently named Arduino component; `M5GFX_ARDUINO_COMPONENT=OFF` disables the automatic dependency.
- Several matching Arduino components in one build is a configuration error (`FATAL_ERROR` with the variable to set).
- README: note on using the library with Arduino as an ESP-IDF component.

Note for hybrid projects: once Arduino is part of the build, every component that includes this library's headers now compiles them in Arduino mode, which is what the application already did.

## Verification

- ESP-IDF 5.5.1 + arduino-esp32 3.3.3 as a component, ESP32: without this change `getPanel()` is null and the panel is never initialised; with it the display works. Setting `M5GFX_ARDUINO_COMPONENT=OFF` restores the old behaviour, a custom name and an empty value behave as documented.
- Pure ESP-IDF 5.5.4 and 6.0.2 builds without Arduino: unchanged (no dependency added).
- CI on the ainyan03 fork is green for this branch.
