### PR TITLE
Bus_SPI: initialize spi_bus_config_t::dma_burst_size for ESP-IDF 6.1

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -847,6 +847,9 @@ namespace lgfx
         buscfg.flags = SPICOMMON_BUSFLAG_MASTER;
         buscfg.intr_flags = 0;
 #if defined (ESP_IDF_VERSION_VAL)
+  #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0))
+        buscfg.dma_burst_size = 0; // 0 = driver default. memset(~0u) leaves 0xFFFFFFFF, which the GDMA driver rejects
+  #endif
   #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
     #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0))
         buscfg.data_io_default_level = 0;


### PR DESCRIPTION
Fixes #278.

ESP-IDF v6.1 added `dma_burst_size` to `spi_bus_config_t`. `spi::init()` seeds the struct with `memset(&buscfg, ~0u, ...)` so that every `*_io_num` defaults to -1, which leaves the new field at `0xFFFFFFFF`. On chips whose GDMA burst size is configurable the driver rejects that value, `spi_bus_initialize()` fails inside `alloc_dma_chan()`, and its error path then panics (`LoadProhibited`), so `init()` boot-loops.

This sets `dma_burst_size = 0` (driver default) on v6.1 and later. The assignment is placed inside the existing `#if defined (ESP_IDF_VERSION_VAL)` block so that toolchains without `esp_idf_version.h` keep compiling.

Affected chips (from the v6.1 sources): ESP32-S3 / C5 / C61 / H4 (`GDMA_LL_AHB_BURST_SIZE_ADJUSTABLE`) and ESP32-P4 / S31 (`SOC_AXI_GDMA_SUPPORTED`). ESP32 / S2 have no GDMA, and C3 / C6 / C2 / H2 force the default burst size regardless of the requested value, so they were never affected.

## Verification

A/B on hardware with ESP-IDF v6.1 (tag), M5GFX from `develop` vs. this branch:

| Board | Chip | Without fix | With fix |
| --- | --- | --- | --- |
| StickS3 | ESP32-S3 | `invalid max_data_burst_size: 4294967295` → panic loop | boots, display OK |
| CoreS3 | ESP32-S3 | same | boots, display OK |
| ToughC5 | ESP32-C5 | same | boots, display OK |
| Tab5 | ESP32-P4 | same (via `spi::init` on Port B, since the DSI panel path does not touch SPI) | `spi::init` OK, DSI display OK |

- No behaviour change on earlier IDF versions (the field does not exist there); Arduino-ESP32 3.x (ESP-IDF 5.5) build checked.
- CI on the fork: Arduino / ESP-IDF build workflows green.
