### PR TITLE
Bus_SPI: zero-initialize spi_bus_config_t instead of memset(~0u)

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -847,6 +847,9 @@ namespace lgfx
         buscfg.flags = SPICOMMON_BUSFLAG_MASTER;
         buscfg.intr_flags = 0;
 #if defined (ESP_IDF_VERSION_VAL)
+  #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0))
+        buscfg.dma_burst_size = 0; // 0 = driver default. memset(~0u) leaves 0xFFFFFFFF, which the GDMA driver rejects
+  #endif
   #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
     #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0))
         buscfg.data_io_default_level = 0;

--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -838,22 +838,27 @@ namespace lgfx
  // バスの設定にはESP-IDFのSPIドライバを使用する。;
       if (_spi_dev_handle[spi_host] == nullptr)
       {
-        spi_bus_config_t buscfg;
-        memset(&buscfg, ~0u, sizeof(spi_bus_config_t));
+        // Zero-initialize, following ESP-IDF's own aggregate-initializer convention: every current
+        // non-pin field is valid at 0 (notably dma_burst_size = 0 selects the driver default on v6.1,
+        // and data_io_default_level = 0 is the Low level used before). Unused pin fields are set
+        // to -1 explicitly because 0 would mean GPIO0.
+        spi_bus_config_t buscfg = {};
         buscfg.mosi_io_num = spi_mosi;
         buscfg.miso_io_num = spi_miso;
         buscfg.sclk_io_num = spi_sclk;
+        buscfg.quadwp_io_num = -1;
+        buscfg.quadhd_io_num = -1;
         buscfg.max_transfer_sz = 1;
         buscfg.flags = SPICOMMON_BUSFLAG_MASTER;
         buscfg.intr_flags = 0;
 #if defined (ESP_IDF_VERSION_VAL)
-  #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0))
-        buscfg.dma_burst_size = 0; // 0 = driver default. memset(~0u) leaves 0xFFFFFFFF, which the GDMA driver rejects
+  #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0))
+        buscfg.data4_io_num = -1;
+        buscfg.data5_io_num = -1;
+        buscfg.data6_io_num = -1;
+        buscfg.data7_io_num = -1;
   #endif
   #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
-    #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0))
-        buscfg.data_io_default_level = 0;
-    #endif
         buscfg.isr_cpu_id = ESP_INTR_CPU_AFFINITY_AUTO;
   #elif (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0))
         buscfg.isr_cpu_id = INTR_CPU_ID_AUTO;


### PR DESCRIPTION
Follow-up to #280 (stacked on it; the first commit here is that PR's commit). Please merge #280 first, or merge this one alone since it contains both.

#280 patched the one field that ESP-IDF v6.1 added. This replaces the underlying `memset(&buscfg, ~0u, ...)` in `spi::init()` so the same class of problem cannot come back with the next field ESP-IDF adds:

- `memset(~0u)` seeded every `*_io_num` with -1 in one stroke, but also left every non-pin field at `0xFFFFFFFF`, which is exactly what broke on v6.1 (`dma_burst_size`).
- ESP-IDF's own examples aggregate-initialize `spi_bus_config_t` (unspecified members become 0). Following that convention, the struct is now zero-initialized and only the unused pin fields are set to -1 explicitly (`quadwp`/`quadhd` always; `data4..7` under a v4.4+ guard, where they exist), because 0 would denote GPIO0.
- With this, every non-pin field present in IDF 3.2 through 6.1 receives a valid value: `dma_burst_size = 0` is the driver default on v6.1, and `data_io_default_level = 0` is the same Low level that was assigned explicitly before. The v6.1-specific assignment from #280 is therefore removed again, and `initQuad()` (already a designated initializer) and `init()` now follow the same pattern.
- Version guards keep the nested `#if defined (ESP_IDF_VERSION_VAL)` / `#if (ESP_IDF_VERSION >= ...)` form so toolchains without `esp_idf_version.h` still preprocess.

## Verification

- A/B on hardware with ESP-IDF v6.1 (tag): StickS3 and CoreS3 (ESP32-S3), ToughC5 (ESP32-C5), Tab5 (ESP32-P4) all initialise and draw normally with this branch (they boot-loop on `develop`). Smoke test on ESP32 (Core BASIC, no GDMA) with ESP-IDF v6.0: initialises and draws normally.
- Builds: ESP-IDF v6.1 (S3 / C5 / P4), ESP-IDF v6.0 (ESP32), Arduino-ESP32 2.0.3 and 2.0.17 (IDF 4.4, the `data4..7` guard boundary), Arduino-ESP32 3.x (IDF 5.5).
- CI on the fork: all build workflows green.
