### PR TITLE
Avoid the legacy driver/i2c.h include in M5GFX.cpp

### DIFF
--- a/src/M5GFX.cpp
+++ b/src/M5GFX.cpp
@@ -10,7 +10,11 @@
 #include <soc/soc.h>
 #include <nvs.h>
 #include <esp_log.h>
-#include <driver/i2c.h>
+#if __has_include(<driver/i2c_master.h>)
+ #include <driver/i2c_master.h>
+#else
+ #include <driver/i2c.h>
+#endif
 #include <soc/efuse_reg.h>
 #include <soc/gpio_reg.h>
 


### PR DESCRIPTION
## Summary

`M5GFX.cpp` includes the legacy `driver/i2c.h` only to get `i2c_port_t` / `I2C_NUM_x`.
ESP-IDF 6.x marks that header as EOL and emits a `CRITICAL WARNING` pragma on every include; it is scheduled for removal in IDF v7.

This change includes `driver/i2c_master.h` when it is available (IDF 5.2+) and falls back to `driver/i2c.h` otherwise (IDF 4.4 / Arduino core 2.x), the same pattern already used in `platforms/esp32/common.cpp`.
No functional change.

## Verified

- ESP-IDF 6.1 (esp32s3): the `driver/i2c.h` EOL warning from `M5GFX.cpp` no longer appears, build passes
- Arduino core 2.0.3 (IDF 4.4, fallback path), Arduino core 3.3.9, ESP-IDF 5.5.1: build passes
- Fork CI green on this branch
